### PR TITLE
feat: inline size overlay on YouTube video pages

### DIFF
--- a/extension/background.ts
+++ b/extension/background.ts
@@ -10,6 +10,16 @@ import {
 } from "./youtube";
 import { getAPIFallbackSetting } from "./utils";
 
+function sendProgress(tabId: number | undefined, stage: string, tag: string) {
+    if (tabId == null) return;
+    chrome.tabs.sendMessage(tabId, { type: "tubesize_progress", stage, tag }).catch(() => {});
+}
+
+function sendResult(tabId: number | undefined, result: BackgroundResponse, tag: string) {
+    if (tabId == null) return;
+    chrome.tabs.sendMessage(tabId, { type: "tubesize_result", tag, ...result }).catch(() => {});
+}
+
 chrome.runtime.onMessage.addListener(
     (
         message: {
@@ -40,69 +50,93 @@ chrome.runtime.onMessage.addListener(
         clearBadge(tabId);
 
         (async () => {
-            const cached = await getFromStorage(tag);
-
-            if (cached) {
-                addBadge(tabId);
-                sendResponse({
-                    success: true,
-                    data: cached.response,
-                    cached: true,
-                    createdAt: cached.createdAt,
-                });
-                return;
-            }
-
             try {
-                let data: RawData;
-                try {
-                    if (message.html) {
-                        data = extractYtInitialForVideo(message.html, tag);
-                    } else {
-                        throw new Error("no html");
-                    }
-                } catch (err) {
-                    const fetchedHtml = await fetchHTMLPage(tag);
-                    data = extractYtInitialForVideo(fetchedHtml, tag);
-                }
+                sendProgress(tabId, "checking_cache", tag);
+                const cached = await getFromStorage(tag);
 
-                const rawFormats = parseDataFromYtInitial(data);
-                const humanizedFormats = humanizeData(rawFormats);
-
-                await saveToStorage(tag, humanizedFormats);
-                addBadge(tabId);
-                sendResponse({
-                    success: true,
-                    data: humanizedFormats,
-                    cached: false,
-                    api: false,
-                });
-            } catch (err) {
-                try {
-                    const useAPIFallback = await getAPIFallbackSetting();
-                    if (!useAPIFallback) {
-                        throw new Error("Skipped API Fallback");
-                    }
-
-                    const apiData = await fetchAPI(tag);
-                    // Do not cache API responses, in order to keep the cache consistent.
-                    // Because the API response is different than the data we extract from the html page.
+                if (cached) {
                     addBadge(tabId);
-                    sendResponse({
+                    const result: BackgroundResponse = {
                         success: true,
-                        data: apiData,
-                        cached: false,
-                        api: true,
-                    });
-                } catch (apiErr) {
-                    clearBadge(tabId);
-                    sendResponse({
-                        success: false,
-                        data: null,
-                        cached: false,
-                        message: apiErr instanceof Error ? apiErr.message : "Unknown error",
-                    });
+                        data: cached.response,
+                        cached: true,
+                        createdAt: cached.createdAt,
+                    };
+                    sendResponse(result);
+                    sendResult(tabId, result, tag);
+                    return;
                 }
+
+                try {
+                    let data: RawData;
+                    try {
+                        sendProgress(tabId, "parsing_page", tag);
+                        if (message.html) {
+                            data = extractYtInitialForVideo(message.html, tag);
+                        } else {
+                            throw new Error("no html");
+                        }
+                    } catch (err) {
+                        sendProgress(tabId, "fetching_youtube", tag);
+                        const fetchedHtml = await fetchHTMLPage(tag);
+                        data = extractYtInitialForVideo(fetchedHtml, tag);
+                    }
+
+                    const rawFormats = parseDataFromYtInitial(data);
+                    const humanizedFormats = humanizeData(rawFormats);
+
+                    await saveToStorage(tag, humanizedFormats);
+                    addBadge(tabId);
+                    const result: BackgroundResponse = {
+                        success: true,
+                        data: humanizedFormats,
+                        cached: false,
+                        api: false,
+                    };
+                    sendResponse(result);
+                    sendResult(tabId, result, tag);
+                } catch (err) {
+                    try {
+                        const useAPIFallback = await getAPIFallbackSetting();
+                        if (!useAPIFallback) {
+                            throw new Error("Skipped API Fallback");
+                        }
+
+                        sendProgress(tabId, "using_api", tag);
+                        const apiData = await fetchAPI(tag);
+                        // Do not cache API responses, in order to keep the cache consistent.
+                        // Because the API response is different than the data we extract from the html page.
+                        addBadge(tabId);
+                        const apiResult: BackgroundResponse = {
+                            success: true,
+                            data: apiData,
+                            cached: false,
+                            api: true,
+                        };
+                        sendResponse(apiResult);
+                        sendResult(tabId, apiResult, tag);
+                    } catch (apiErr) {
+                        clearBadge(tabId);
+                        const errResult: BackgroundResponse = {
+                            success: false,
+                            data: null,
+                            cached: false,
+                            message: apiErr instanceof Error ? apiErr.message : "Unknown error",
+                        };
+                        sendResponse(errResult);
+                        sendResult(tabId, errResult, tag);
+                    }
+                }
+            } catch (unexpectedErr) {
+                const unexpResult: BackgroundResponse = {
+                    success: false,
+                    data: null,
+                    cached: false,
+                    message:
+                        unexpectedErr instanceof Error ? unexpectedErr.message : "Unknown error",
+                };
+                sendResponse(unexpResult);
+                sendResult(tabId, unexpResult, tag);
             }
         })();
 

--- a/extension/content.ts
+++ b/extension/content.ts
@@ -95,5 +95,8 @@ window.addEventListener("yt-navigate-finish", async () => {
     if (lastTag === tag) return;
     lastTag = tag;
 
-    fetchAndDisplaySizes(tag);
+    fetchAndDisplaySizes(tag).catch((err) => {
+        console.error("[content] fetchAndDisplaySizes failed", err);
+        showError("Failed to load sizes");
+    });
 });

--- a/extension/content.ts
+++ b/extension/content.ts
@@ -1,41 +1,99 @@
+import type { BackgroundResponse } from "./types";
 import { extractVideoId } from "./utils";
+import { initOverlay, updateProgress, renderData, showError, destroyOverlay } from "./overlay";
 
-async function sendRuntimeMessage(message: { type: string; tag?: string; html?: string }) {
+let lastTag: string | undefined = undefined;
+
+// Listen for progress and result messages pushed from the background
+// Validate message.tag against lastTag to discard stale results from previous videos
+chrome.runtime.onMessage.addListener(
+    (message: { type: string; stage?: string; tag?: string } & Partial<BackgroundResponse>) => {
+        if (message.type === "tubesize_progress" && message.stage && message.tag === lastTag) {
+            updateProgress(message.stage);
+        }
+
+        if (message.type === "tubesize_result" && message.tag === lastTag) {
+            if (message.success && message.data) {
+                renderData(message.data, message.cached ?? false, message.createdAt).catch((err) =>
+                    console.error("[content] renderData failed", err),
+                );
+            } else {
+                showError(message.message ?? "Failed to load sizes");
+            }
+        }
+    },
+);
+
+async function sendBadgeMessage(type: string) {
     try {
-        await chrome.runtime.sendMessage(message);
+        await chrome.runtime.sendMessage({ type });
     } catch (err) {
         if (err instanceof Error && err.message.includes("Extension context invalidated")) {
             console.warn("[content] Extension context invalidated. Reload the page to reconnect.");
             return;
         }
-
         console.error("[content] Failed to send runtime message", err);
     }
 }
 
-async function init(videoTag: string) {
+async function getOverlaySetting(): Promise<boolean> {
+    const { showOverlay = true } = await chrome.storage.sync.get("showOverlay");
+    return showOverlay as boolean;
+}
+
+async function fetchAndDisplaySizes(tag: string, isRefresh = false) {
+    if (!isRefresh) {
+        const showOverlay = await getOverlaySetting();
+        if (!showOverlay) {
+            destroyOverlay();
+            return;
+        }
+        await initOverlay(tag, () => handleRefresh(tag));
+    }
+
     const scriptsArray = Array.from(document.scripts);
     const ytInitialPlayerResponse = scriptsArray.find((script) => {
         return script.textContent?.includes("ytInitialPlayerResponse");
     });
-
     const scriptContent = ytInitialPlayerResponse?.textContent;
 
-    await sendRuntimeMessage({
-        type: "sendYoutubeUrl",
-        tag: videoTag,
-        html: scriptContent,
+    // Fire and forget. The background will push the result back via
+    // chrome.tabs.sendMessage which is handled by the onMessage listener above.
+    chrome.runtime
+        .sendMessage({
+            type: "sendYoutubeUrl",
+            tag,
+            html: scriptContent,
+        })
+        .catch((err: unknown) => {
+            if (err instanceof Error && err.message.includes("Extension context invalidated")) {
+                return;
+            }
+            showError("Failed to load video sizes");
+        });
+}
+
+async function handleRefresh(tag: string) {
+    await chrome.storage.local.remove(tag);
+    fetchAndDisplaySizes(tag, true).catch((err) => {
+        console.error("[content] handleRefresh failed", err);
+        showError("Refresh failed");
     });
 }
 
-let lastTag: string | undefined = undefined;
 window.addEventListener("yt-navigate-finish", async () => {
-    await sendRuntimeMessage({ type: "clearBadge" });
+    await sendBadgeMessage("clearBadge");
     const url = window.location.href;
     const tag = extractVideoId(url);
+
+    if (!tag) {
+        destroyOverlay();
+        lastTag = undefined;
+        return;
+    }
 
     if (lastTag === tag) return;
     lastTag = tag;
 
-    if (tag) init(tag);
+    fetchAndDisplaySizes(tag);
 });

--- a/extension/options.html
+++ b/extension/options.html
@@ -29,6 +29,16 @@
         </div>
         <div class="section-divider"></div>
         <div class="container">
+            <div class="section-title">Display</div>
+            <div class="api-fallback-row">
+                <label class="api-fallback-toggle" for="showOverlay">
+                    <input type="checkbox" id="showOverlay" checked />
+                    <span class="api-fallback-label">Show sizes on YouTube page</span>
+                </label>
+            </div>
+        </div>
+        <div class="section-divider"></div>
+        <div class="container">
             <div class="section-title">API Fallback</div>
             <div class="api-fallback-row">
                 <label class="api-fallback-toggle" for="apiFallback">

--- a/extension/options.ts
+++ b/extension/options.ts
@@ -69,6 +69,12 @@ getElement("apiFallback", false)?.addEventListener("change", (event) => {
     chrome.storage.sync.set({ apiFallback: checked });
 });
 
+// Listen to overlay toggle
+getElement("showOverlay", false)?.addEventListener("change", (event) => {
+    const checked = (event.target as HTMLInputElement).checked;
+    chrome.storage.sync.set({ showOverlay: checked });
+});
+
 // Load options from chrome storage when options page is opened
 async function loadOptions() {
     const allOptions = await chrome.storage.sync.get();
@@ -94,6 +100,12 @@ async function loadOptions() {
             apiFallback: boolean;
         };
         apiFallbackBtn.checked = apiFallback;
+    }
+
+    const overlayBtn = getElement("showOverlay", false) as HTMLInputElement | null;
+    if (overlayBtn) {
+        const { showOverlay = true } = allOptions as { showOverlay: boolean };
+        overlayBtn.checked = showOverlay;
     }
 }
 loadOptions();

--- a/extension/overlay.ts
+++ b/extension/overlay.ts
@@ -1,0 +1,509 @@
+import type { APIData, HumanizedFormat } from "./types";
+import { getOptions } from "./utils";
+import CONFIG from "./constants";
+import ms from "ms";
+
+const OVERLAY_HOST_ID = "tubesize-overlay";
+const COLLAPSE_STORAGE_KEY = "tubesizeCollapsed";
+const OVERLAY_TIMEOUT_MS = 25000;
+const MAX_ANCHOR_RETRIES = 10;
+const ANCHOR_RETRY_INTERVAL = 500;
+
+let shadowRoot: ShadowRoot | null = null;
+let currentTag: string | null = null;
+let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+let onRefreshCallback: (() => void) | null = null;
+
+const STAGE_LABELS: Record<string, string> = {
+    checking_cache: "Checking cache\u2026",
+    parsing_page: "Reading page data\u2026",
+    fetching_youtube: "Fetching from YouTube\u2026",
+    using_api: "Using backup server\u2026",
+};
+
+function getStyles(): string {
+    return `
+        :host {
+            display: block;
+            margin-top: 24px;
+        }
+
+        .ts-bar {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-wrap: wrap;
+            padding-top: 16px;
+            border-top: 1px solid var(--yt-spec-10-percent-layer, rgba(255,255,255,0.15));
+        }
+
+        .ts-label {
+            font-size: 13px;
+            font-weight: 500;
+            color: var(--yt-spec-text-secondary, #aaa);
+            cursor: pointer;
+            user-select: none;
+            flex-shrink: 0;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            transition: color 0.15s;
+        }
+
+        .ts-label:hover {
+            color: var(--yt-spec-text-primary, #f1f1f1);
+        }
+
+        .ts-label:focus-visible {
+            outline: 2px solid var(--yt-spec-text-secondary, #aaa);
+            outline-offset: 2px;
+            border-radius: 2px;
+        }
+
+        .ts-arrow {
+            font-size: 10px;
+            transition: transform 0.2s;
+        }
+
+        .ts-arrow.collapsed {
+            transform: rotate(-90deg);
+        }
+
+        .ts-content {
+            display: contents;
+        }
+
+        .ts-content.collapsed {
+            display: none;
+        }
+
+        .ts-chips {
+            display: flex;
+            gap: 6px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        .ts-chip {
+            font-size: 12px;
+            color: var(--yt-spec-text-primary, #f1f1f1);
+            padding: 3px 10px;
+            border-radius: 14px;
+            background: var(--yt-spec-badge-chip-color, rgba(255, 255, 255, 0.08));
+            cursor: pointer;
+            transition: background 0.15s;
+            white-space: nowrap;
+            line-height: 1.4;
+        }
+
+        .ts-chip:hover {
+            background: var(--yt-spec-10-percent-layer, rgba(255, 255, 255, 0.15));
+        }
+
+        .ts-chip.copied {
+            background: rgba(40, 167, 69, 0.2);
+        }
+
+        .ts-chip:focus-visible {
+            outline: 2px solid var(--yt-spec-text-primary, #f1f1f1);
+            outline-offset: 2px;
+        }
+
+        .ts-loading {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .ts-spinner {
+            width: 12px;
+            height: 12px;
+            border: 1.5px solid var(--yt-spec-10-percent-layer, rgba(255, 255, 255, 0.2));
+            border-top-color: var(--yt-spec-text-primary, #f1f1f1);
+            border-radius: 50%;
+            animation: ts-spin 0.8s linear infinite;
+            flex-shrink: 0;
+        }
+
+        @keyframes ts-spin {
+            to { transform: rotate(360deg); }
+        }
+
+        .ts-stage {
+            font-size: 12px;
+            color: var(--yt-spec-text-secondary, #aaa);
+        }
+
+        .ts-btn {
+            background: transparent;
+            border: none;
+            color: var(--yt-spec-text-secondary, #aaa);
+            font-size: 14px;
+            cursor: pointer;
+            padding: 2px 4px;
+            line-height: 1;
+            transition: color 0.15s;
+            flex-shrink: 0;
+        }
+
+        .ts-btn:hover {
+            color: var(--yt-spec-text-primary, #f1f1f1);
+        }
+
+        .ts-error-text {
+            font-size: 12px;
+            color: #ff6b6b;
+        }
+
+        .ts-retry-btn {
+            background: transparent;
+            border: 1px solid rgba(255, 107, 107, 0.3);
+            color: #ff6b6b;
+            padding: 2px 10px;
+            border-radius: 14px;
+            cursor: pointer;
+            font-size: 11px;
+            transition: background 0.15s;
+        }
+
+        .ts-retry-btn:hover {
+            background: rgba(255, 107, 107, 0.1);
+        }
+
+        .ts-cached {
+            font-size: 11px;
+            color: var(--yt-spec-text-secondary, #aaa);
+            font-style: italic;
+        }
+    `;
+}
+
+function findAnchor(): { element: HTMLElement; method: "append" | "prepend" } | null {
+    // Best: below the video title/owner row, inside the main info area
+    const aboveFold = document.querySelector<HTMLElement>("#above-the-fold");
+    if (aboveFold) return { element: aboveFold, method: "append" };
+
+    // Fallback: top of the section below the fold
+    const belowFold = document.querySelector<HTMLElement>("#below-the-fold");
+    if (belowFold) return { element: belowFold, method: "prepend" };
+
+    // Last resort: sidebar
+    const secondary = document.querySelector<HTMLElement>("#secondary-inner");
+    if (secondary) return { element: secondary, method: "prepend" };
+
+    return null;
+}
+
+function waitForAnchor(): Promise<{ element: HTMLElement; method: "append" | "prepend" } | null> {
+    return new Promise((resolve) => {
+        let attempts = 0;
+
+        function tryFind() {
+            const result = findAnchor();
+            if (result) {
+                resolve(result);
+                return;
+            }
+            attempts++;
+            if (attempts >= MAX_ANCHOR_RETRIES) {
+                resolve(null);
+                return;
+            }
+            setTimeout(tryFind, ANCHOR_RETRY_INTERVAL);
+        }
+
+        tryFind();
+    });
+}
+
+function setContentState() {
+    if (!shadowRoot) return;
+    const content = shadowRoot.querySelector(".ts-content");
+    if (!content) return;
+
+    content.textContent = "";
+    return content;
+}
+
+function showLoadingState() {
+    const content = setContentState();
+    if (!content) return;
+
+    const loading = document.createElement("div");
+    loading.className = "ts-loading";
+
+    const spinner = document.createElement("div");
+    spinner.className = "ts-spinner";
+
+    const stage = document.createElement("span");
+    stage.className = "ts-stage";
+    stage.textContent = "Loading\u2026";
+
+    loading.append(spinner, stage);
+    content.append(loading);
+}
+
+function showTimeout() {
+    const content = setContentState();
+    if (!content) return;
+
+    const msg = document.createElement("span");
+    msg.className = "ts-error-text";
+    msg.textContent = "Taking too long\u2026";
+
+    const retryBtn = document.createElement("button");
+    retryBtn.type = "button";
+    retryBtn.className = "ts-retry-btn";
+    retryBtn.textContent = "Retry";
+    retryBtn.addEventListener("click", () => handleRefreshClick());
+
+    content.append(msg, retryBtn);
+}
+
+function toggleCollapse() {
+    if (!shadowRoot) return;
+
+    const content = shadowRoot.querySelector(".ts-content");
+    const arrow = shadowRoot.querySelector(".ts-arrow");
+    const refreshBtn = shadowRoot.querySelector(".ts-refresh");
+    if (!content || !arrow) return;
+
+    const isCollapsed = content.classList.toggle("collapsed");
+    arrow.classList.toggle("collapsed", isCollapsed);
+    if (refreshBtn) (refreshBtn as HTMLElement).style.display = isCollapsed ? "none" : "";
+
+    chrome.storage.local.set({ [COLLAPSE_STORAGE_KEY]: isCollapsed });
+}
+
+function handleRefreshClick() {
+    showLoadingState();
+
+    // Uncollapse if collapsed
+    const content = shadowRoot?.querySelector(".ts-content");
+    const arrow = shadowRoot?.querySelector(".ts-arrow");
+    if (content?.classList.contains("collapsed")) {
+        content.classList.remove("collapsed");
+        arrow?.classList.remove("collapsed");
+    }
+
+    clearTimeoutTimer();
+    timeoutTimer = setTimeout(() => {
+        if (!shadowRoot) return;
+        const loadingEl = shadowRoot.querySelector(".ts-loading");
+        if (loadingEl) showTimeout();
+    }, OVERLAY_TIMEOUT_MS);
+
+    onRefreshCallback?.();
+}
+
+function clearTimeoutTimer() {
+    if (timeoutTimer !== null) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = null;
+    }
+}
+
+export async function initOverlay(tag: string, onRefresh: () => void) {
+    destroyOverlay();
+    currentTag = tag;
+    onRefreshCallback = onRefresh;
+
+    const anchor = await waitForAnchor();
+    if (!anchor) {
+        console.warn("[overlay] No anchor element found");
+        return;
+    }
+
+    if (currentTag !== tag) return;
+
+    const host = document.createElement("div");
+    host.id = OVERLAY_HOST_ID;
+    shadowRoot = host.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = getStyles();
+    shadowRoot.append(style);
+
+    // Single-row bar
+    const bar = document.createElement("div");
+    bar.className = "ts-bar";
+
+    // Label (clickable to toggle)
+    const label = document.createElement("span");
+    label.className = "ts-label";
+    label.textContent = "TubeSize";
+    label.setAttribute("role", "button");
+    label.setAttribute("tabindex", "0");
+    label.setAttribute("aria-label", "Toggle TubeSize overlay");
+    label.addEventListener("click", toggleCollapse);
+    label.addEventListener("keydown", (e: KeyboardEvent) => {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggleCollapse();
+        }
+    });
+
+    const arrow = document.createElement("span");
+    arrow.className = "ts-arrow";
+    arrow.textContent = "\u25BE";
+    label.append(arrow);
+
+    // Content area (loading/chips/error appear here)
+    const content = document.createElement("div");
+    content.className = "ts-content";
+
+    // Refresh button
+    const refreshBtn = document.createElement("button");
+    refreshBtn.type = "button";
+    refreshBtn.className = "ts-btn ts-refresh";
+    refreshBtn.title = "Refresh";
+    refreshBtn.setAttribute("aria-label", "Refresh sizes");
+    refreshBtn.textContent = "\u21BB";
+    refreshBtn.addEventListener("click", handleRefreshClick);
+
+    bar.append(label, content, refreshBtn);
+    shadowRoot.append(bar);
+
+    // Show loading
+    showLoadingState();
+
+    // Restore collapse state
+    const result = await chrome.storage.local.get(COLLAPSE_STORAGE_KEY);
+    if (currentTag !== tag) return;
+    if (result[COLLAPSE_STORAGE_KEY]) {
+        content.classList.add("collapsed");
+        arrow.classList.add("collapsed");
+        refreshBtn.style.display = "none";
+    }
+
+    // Inject
+    if (anchor.method === "append") {
+        anchor.element.append(host);
+    } else {
+        anchor.element.prepend(host);
+    }
+
+    // Timeout
+    timeoutTimer = setTimeout(() => {
+        if (!shadowRoot) return;
+        const loadingEl = shadowRoot.querySelector(".ts-loading");
+        if (loadingEl) showTimeout();
+    }, OVERLAY_TIMEOUT_MS);
+}
+
+export function updateProgress(stage: string) {
+    if (!shadowRoot) return;
+
+    const stageEl = shadowRoot.querySelector(".ts-stage");
+    if (stageEl) {
+        stageEl.textContent = STAGE_LABELS[stage] ?? stage;
+    }
+}
+
+export async function renderData(
+    data: APIData | HumanizedFormat,
+    cached: boolean,
+    createdAt?: string,
+) {
+    if (!shadowRoot) return;
+    clearTimeoutTimer();
+
+    const content = shadowRoot.querySelector(".ts-content");
+    if (!content) return;
+
+    content.textContent = "";
+
+    const options = await getOptions();
+    const enabledOptions = CONFIG.optionIDs.filter((id) => (options[id] as boolean) ?? true);
+
+    if (enabledOptions.length === 0) {
+        const msg = document.createElement("span");
+        msg.className = "ts-error-text";
+        msg.textContent = "All resolutions disabled";
+        content.append(msg);
+        return;
+    }
+
+    // Chips
+    const chips = document.createElement("div");
+    chips.className = "ts-chips";
+
+    const formats = [...data.videoFormats].reverse();
+
+    for (const format of formats) {
+        const optionKey = format.height ? `p${format.height}` : null;
+        if (!optionKey || !enabledOptions.includes(optionKey)) continue;
+
+        const chip = document.createElement("span");
+        chip.className = "ts-chip";
+        chip.textContent = `${format.height}p  ${format.size}`;
+        chip.title = "Click to copy";
+        chip.setAttribute("role", "button");
+        chip.setAttribute("tabindex", "0");
+
+        chip.addEventListener("click", async () => {
+            try {
+                await navigator.clipboard.writeText(`${format.height}p: ${format.size}`);
+                chip.classList.add("copied");
+                setTimeout(() => chip.classList.remove("copied"), 600);
+            } catch {
+                // Clipboard API may not be available in all contexts
+            }
+        });
+        chip.addEventListener("keydown", (e: KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                chip.click();
+            }
+        });
+
+        chips.append(chip);
+    }
+
+    content.append(chips);
+
+    // Cached note
+    if (cached && createdAt) {
+        const note = document.createElement("span");
+        note.className = "ts-cached";
+
+        const timeInMs = Date.now() - new Date(createdAt).getTime();
+        if (timeInMs < CONFIG.CACHE_JUST_NOW_THRESHOLD) {
+            note.textContent = "cached just now";
+        } else {
+            note.textContent = `cached ${ms(timeInMs, { long: true })} ago`;
+        }
+        content.append(note);
+    }
+}
+
+export function showError(message: string) {
+    if (!shadowRoot) return;
+    clearTimeoutTimer();
+
+    const content = shadowRoot.querySelector(".ts-content");
+    if (!content) return;
+
+    content.textContent = "";
+
+    const msg = document.createElement("span");
+    msg.className = "ts-error-text";
+    msg.textContent = message;
+
+    const retryBtn = document.createElement("button");
+    retryBtn.type = "button";
+    retryBtn.className = "ts-retry-btn";
+    retryBtn.textContent = "Retry";
+    retryBtn.addEventListener("click", () => handleRefreshClick());
+
+    content.append(msg, retryBtn);
+}
+
+export function destroyOverlay() {
+    clearTimeoutTimer();
+    shadowRoot = null;
+    currentTag = null;
+    onRefreshCallback = null;
+
+    document.getElementById(OVERLAY_HOST_ID)?.remove();
+}


### PR DESCRIPTION
## What this adds

A lightweight inline widget that shows per-resolution file sizes directly on YouTube watch pages, below the video title -- no need to open the popup.

<img width="1318" height="886" alt="image" src="https://github.com/user-attachments/assets/ec40b4b8-090c-49b5-b2d0-c1cb7374b33c" />

## How it works

A Shadow DOM host element is injected into `#above-the-fold` (with fallbacks to `#below-the-fold` and `#secondary-inner`). It displays a single horizontal chip bar:

```
TubeSize  [1080p  450 MB]  [720p  280 MB]  [480p  140 MB]  [360p  80 MB]  ↻
```

- Chips respect the resolution toggles set in Options
- Click any chip to copy it to clipboard
- Click the "TubeSize" label to collapse/expand (state persisted to `chrome.storage.local`)
- Refresh button clears cache for that video and re-fetches
- CSS variables from YouTube (`--yt-spec-*`) are inherited through the shadow boundary for automatic light/dark theme matching

## Loading states

The overlay shows a live progress indicator while the background runs through the fallback chain:

| Stage | Label shown |
|---|---|
| `checking_cache` | Checking cache... |
| `parsing_page` | Reading page data... |
| `fetching_youtube` | Fetching from YouTube... |
| `using_api` | Using backup server... |

A 25-second timeout guard shows a "Taking too long..." retry prompt if something stalls.

## Reliability fix: push-based result delivery

The previous approach awaited `chrome.runtime.sendMessage(...)` response from the content script side. In MV3, a service worker can go dormant between the initial request and the response callback, causing the `sendResponse` closure to become stale and the Promise to never resolve -- which is why the refresh button would get stuck.

This PR switches to a push model:

- `content.ts` fires the message and forgets (no `.then()` on the response)
- `background.ts` calls both `sendResponse(result)` (for popup compatibility) AND `chrome.tabs.sendMessage(tabId, { type: "tubesize_result", ...result })` to push the result directly into the content script
- `content.ts` handles both `tubesize_progress` and `tubesize_result` message types inside a single `onMessage` listener

This ensures results always arrive regardless of service worker lifecycle.

## Options toggle

A new "Display" section in the Options page lets users disable the overlay entirely:

- Options page: "Show sizes on YouTube page" checkbox (on by default)
- Stored in `chrome.storage.sync` as `showOverlay`
- Overlay is skipped entirely when the setting is off

## Files changed

| File | Change |
|---|---|
| `extension/overlay.ts` | New -- Shadow DOM overlay widget |
| `extension/content.ts` | Integrate overlay, push-based messaging |
| `extension/background.ts` | `sendResult()` helper, dual delivery |
| `extension/options.html` | Display section with overlay toggle |
| `extension/options.ts` | Load and persist `showOverlay` setting |

## Testing

- Build: `pnpm run build` passes (12.1 kb content, 10.6 kb background)
- Type check: `tsc --noEmit` passes with zero errors
- Tests: 13/13 pass
- Tested manually on YouTube watch pages in Chrome