### PR TITLE
Show video sizes in the YouTube quality menu

### DIFF
--- a/tubesize/src/components/options/qualityMenuSetting.tsx
+++ b/tubesize/src/components/options/qualityMenuSetting.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { getFromSyncCache, setToSyncCache } from "@lib/cache";
+
+export default function QualityMenuSetting() {
+    const [showQualitySizesInPlayerMenu, setShowQualitySizesInPlayerMenu] = useState(true);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const value = await getFromSyncCache("showQualitySizesInPlayerMenu");
+                setShowQualitySizesInPlayerMenu(value !== false);
+            } catch (err) {
+                console.error("Failed to load player quality menu setting from sync storage:", err);
+                setShowQualitySizesInPlayerMenu(true);
+            }
+        })();
+    }, []);
+
+    return (
+        <div className="container">
+            <div className="section-title">YouTube Player Menu</div>
+            <div className="api-fallback-row">
+                <label className="api-fallback-toggle">
+                    <input
+                        type="checkbox"
+                        checked={showQualitySizesInPlayerMenu}
+                        onChange={async (event) => {
+                            const isChecked = event.target.checked;
+                            await setToSyncCache({
+                                showQualitySizesInPlayerMenu: isChecked,
+                            });
+                            setShowQualitySizesInPlayerMenu(isChecked);
+                        }}
+                    />
+                    <span className="api-fallback-label">Show sizes in quality settings</span>
+                </label>
+            </div>
+        </div>
+    );
+}

--- a/tubesize/src/content.ts
+++ b/tubesize/src/content.ts
@@ -4,9 +4,16 @@ import { getFromSyncCache } from "@lib/cache";
 import renderPanel from "./panel";
 
 const QUALITY_SIZE_CLASS = "tubesize-quality-size";
-const QUALITY_MENU_SELECTOR = ".ytp-quality-menu, .ytp-settings-menu";
+const SETTINGS_MENU_SELECTOR = ".ytp-settings-menu";
+const SETTINGS_BUTTON_SELECTOR = ".ytp-settings-button";
 let qualityMenuObserver: MutationObserver | null = null;
-let latestVideoResponse: Awaited<ReturnType<typeof sendRuntimeMessage>>;
+let observedSettingsMenu: HTMLElement | null = null;
+let qualityMenuEventAbortController: AbortController | null = null;
+let qualityMenuApplyFrameId: number | null = null;
+let qualityMenuRefreshFrameId: number | null = null;
+let qualityMenuSyncGeneration = 0;
+let latestVideoResponse: BackgroundResponse | undefined;
+let lastTag: string | undefined = undefined;
 
 type VideoFormats = Exclude<BackgroundResponse["data"], null>["videoFormats"];
 
@@ -22,21 +29,49 @@ function clearInjectedQualitySizes() {
     });
 }
 
-function isQualityMenuMutation(mutations: MutationRecord[]) {
-    return mutations.some((mutation) => {
-        if (mutation.target instanceof Element && mutation.target.closest(QUALITY_MENU_SELECTOR)) {
-            return true;
-        }
+function cancelQualityMenuFrames() {
+    if (qualityMenuApplyFrameId !== null) {
+        cancelAnimationFrame(qualityMenuApplyFrameId);
+        qualityMenuApplyFrameId = null;
+    }
 
-        for (const node of Array.from(mutation.addedNodes)) {
-            if (!(node instanceof Element)) continue;
-            if (node.matches(QUALITY_MENU_SELECTOR) || node.querySelector(QUALITY_MENU_SELECTOR)) {
-                return true;
-            }
-        }
+    if (qualityMenuRefreshFrameId !== null) {
+        cancelAnimationFrame(qualityMenuRefreshFrameId);
+        qualityMenuRefreshFrameId = null;
+    }
+}
 
+function disconnectQualityMenuObserver() {
+    if (!qualityMenuObserver) {
+        observedSettingsMenu = null;
+        return;
+    }
+
+    qualityMenuObserver.disconnect();
+    qualityMenuObserver = null;
+    observedSettingsMenu = null;
+}
+
+function removeQualityMenuListeners() {
+    if (!qualityMenuEventAbortController) return;
+    qualityMenuEventAbortController.abort();
+    qualityMenuEventAbortController = null;
+}
+
+function resetQualityMenuSyncState() {
+    cancelQualityMenuFrames();
+    disconnectQualityMenuObserver();
+    removeQualityMenuListeners();
+    clearInjectedQualitySizes();
+}
+
+function isSettingsMenuOpen(menu: HTMLElement) {
+    const computedStyle = window.getComputedStyle(menu);
+    if (computedStyle.display === "none" || computedStyle.visibility === "hidden") {
         return false;
-    });
+    }
+
+    return menu.getAttribute("aria-hidden") !== "true";
 }
 
 function applyQualitySizes(videoFormats: VideoFormats = []) {
@@ -84,16 +119,10 @@ function applyQualitySizes(videoFormats: VideoFormats = []) {
     });
 }
 
-function setupQualityMenuSizeSync(
-    response: Awaited<ReturnType<typeof sendRuntimeMessage>>,
-    enabled: boolean,
-) {
-    if (qualityMenuObserver) {
-        qualityMenuObserver.disconnect();
-        qualityMenuObserver = null;
-    }
-
-    clearInjectedQualitySizes();
+function setupQualityMenuSizeSync(response: BackgroundResponse | undefined, enabled: boolean) {
+    qualityMenuSyncGeneration += 1;
+    const setupGeneration = qualityMenuSyncGeneration;
+    resetQualityMenuSyncState();
 
     if (!enabled) {
         return;
@@ -107,18 +136,91 @@ function setupQualityMenuSizeSync(
     const scheduleApply = () => {
         if (scheduled) return;
         scheduled = true;
-        requestAnimationFrame(() => {
+        qualityMenuApplyFrameId = requestAnimationFrame(() => {
+            qualityMenuApplyFrameId = null;
             scheduled = false;
+
+            if (setupGeneration !== qualityMenuSyncGeneration) {
+                return;
+            }
+
             applyQualitySizes(response.data?.videoFormats || []);
         });
     };
 
-    scheduleApply();
-    qualityMenuObserver = new MutationObserver((mutations) => {
-        if (!isQualityMenuMutation(mutations)) return;
+    const refreshMenuObserver = () => {
+        const settingsMenu = document.querySelector<HTMLElement>(SETTINGS_MENU_SELECTOR);
+        const shouldObserveMenu = settingsMenu && isSettingsMenuOpen(settingsMenu);
+
+        if (!shouldObserveMenu) {
+            disconnectQualityMenuObserver();
+            return;
+        }
+
+        if (qualityMenuObserver && observedSettingsMenu === settingsMenu) {
+            return;
+        }
+
+        if (qualityMenuObserver) {
+            qualityMenuObserver.disconnect();
+        }
+
+        qualityMenuObserver = new MutationObserver(() => {
+            scheduleApply();
+        });
+        qualityMenuObserver.observe(settingsMenu, {
+            childList: true,
+            subtree: true,
+            characterData: true,
+        });
+        observedSettingsMenu = settingsMenu;
         scheduleApply();
-    });
-    qualityMenuObserver.observe(document.body, { childList: true, subtree: true });
+    };
+
+    const scheduleRefresh = () => {
+        if (qualityMenuRefreshFrameId !== null) return;
+
+        qualityMenuRefreshFrameId = requestAnimationFrame(() => {
+            qualityMenuRefreshFrameId = null;
+
+            if (setupGeneration !== qualityMenuSyncGeneration) {
+                return;
+            }
+
+            refreshMenuObserver();
+        });
+    };
+
+    scheduleApply();
+    refreshMenuObserver();
+
+    qualityMenuEventAbortController = new AbortController();
+    const { signal } = qualityMenuEventAbortController;
+    document.addEventListener(
+        "click",
+        (event) => {
+            const target = event.target;
+            if (!(target instanceof Element)) return;
+
+            if (
+                observedSettingsMenu ||
+                target.closest(SETTINGS_BUTTON_SELECTOR) ||
+                target.closest(SETTINGS_MENU_SELECTOR)
+            ) {
+                scheduleRefresh();
+            }
+        },
+        { capture: true, signal },
+    );
+    document.addEventListener(
+        "keydown",
+        (event) => {
+            if (event.key === "Escape" && observedSettingsMenu) {
+                scheduleRefresh();
+            }
+        },
+        { signal },
+    );
 }
 
 async function syncQualityMenuSetting(showQualitySizesInPlayerMenu?: boolean) {
@@ -128,9 +230,13 @@ async function syncQualityMenuSetting(showQualitySizesInPlayerMenu?: boolean) {
     setupQualityMenuSizeSync(latestVideoResponse, shouldShowQualitySizes);
 }
 
-async function sendRuntimeMessage(message: { type: string; tag?: string; html?: string }) {
+async function sendRuntimeMessage<TResponse = unknown>(message: {
+    type: string;
+    tag?: string;
+    html?: string;
+}): Promise<TResponse | undefined> {
     try {
-        return await chrome.runtime.sendMessage(message);
+        return (await chrome.runtime.sendMessage(message)) as TResponse;
     } catch (err) {
         if (err instanceof Error && err.message.includes("Extension context invalidated")) {
             console.warn("[content] Extension context invalidated. Reload the page to reconnect.");
@@ -150,7 +256,7 @@ async function init(videoTag: string) {
 
     const scriptContent = ytInitialPlayerResponse?.textContent;
 
-    const response = await sendRuntimeMessage({
+    const response = await sendRuntimeMessage<BackgroundResponse>({
         type: "sendYoutubeUrl",
         tag: videoTag,
         html: scriptContent,
@@ -160,7 +266,6 @@ async function init(videoTag: string) {
     await renderPanel(response);
 }
 
-let lastTag: string | undefined = undefined;
 async function handlePageNavigation() {
     await sendRuntimeMessage({ type: "clearBadge" });
     const url = window.location.href;
@@ -169,7 +274,13 @@ async function handlePageNavigation() {
     if (lastTag === tag) return;
     lastTag = tag;
 
-    if (tag) await init(tag);
+    if (!tag) {
+        latestVideoResponse = undefined;
+        setupQualityMenuSizeSync(undefined, false);
+        return;
+    }
+
+    await init(tag);
 }
 
 window.addEventListener("yt-navigate-finish", () => {

--- a/tubesize/src/content.ts
+++ b/tubesize/src/content.ts
@@ -1,5 +1,132 @@
 import { extractVideoTag } from "@lib/utils";
+import type { BackgroundResponse } from "@app-types/types";
+import { getFromSyncCache } from "@lib/cache";
 import renderPanel from "./panel";
+
+const QUALITY_SIZE_CLASS = "tubesize-quality-size";
+const QUALITY_MENU_SELECTOR = ".ytp-quality-menu, .ytp-settings-menu";
+let qualityMenuObserver: MutationObserver | null = null;
+let latestVideoResponse: Awaited<ReturnType<typeof sendRuntimeMessage>>;
+
+type VideoFormats = Exclude<BackgroundResponse["data"], null>["videoFormats"];
+
+function parseHeightFromQualityLabel(text: string) {
+    const match = text.match(/\b(\d{3,4})p\b/i);
+    if (!match) return undefined;
+    return parseInt(match[1], 10);
+}
+
+function clearInjectedQualitySizes() {
+    document.querySelectorAll(`.${QUALITY_SIZE_CLASS}`).forEach((el) => {
+        el.remove();
+    });
+}
+
+function isQualityMenuMutation(mutations: MutationRecord[]) {
+    return mutations.some((mutation) => {
+        if (mutation.target instanceof Element && mutation.target.closest(QUALITY_MENU_SELECTOR)) {
+            return true;
+        }
+
+        for (const node of Array.from(mutation.addedNodes)) {
+            if (!(node instanceof Element)) continue;
+            if (node.matches(QUALITY_MENU_SELECTOR) || node.querySelector(QUALITY_MENU_SELECTOR)) {
+                return true;
+            }
+        }
+
+        return false;
+    });
+}
+
+function applyQualitySizes(videoFormats: VideoFormats = []) {
+    const sizeByHeight = new Map<number, string>();
+    videoFormats.forEach((format) => {
+        sizeByHeight.set(format.height, format.size);
+    });
+
+    const qualityLabels = document.querySelectorAll<HTMLElement>(
+        ".ytp-quality-menu .ytp-menuitem-label, .ytp-settings-menu .ytp-menuitem .ytp-menuitem-label",
+    );
+
+    qualityLabels.forEach((label) => {
+        const baseLabel =
+            label.dataset.tubesizeBaseLabel?.trim() ||
+            label.textContent?.replace(/\s+/g, " ").trim() ||
+            "";
+
+        if (!label.dataset.tubesizeBaseLabel) {
+            label.dataset.tubesizeBaseLabel = baseLabel;
+        }
+
+        const height = parseHeightFromQualityLabel(baseLabel);
+        const size = height ? sizeByHeight.get(height) : undefined;
+        const sizeSpan = label.querySelector<HTMLElement>(`.${QUALITY_SIZE_CLASS}`);
+
+        if (!size) {
+            sizeSpan?.remove();
+            return;
+        }
+
+        if (sizeSpan) {
+            const nextText = ` (${size})`;
+            if (sizeSpan.textContent !== nextText) {
+                sizeSpan.textContent = nextText;
+            }
+            return;
+        }
+
+        const appendedSize = document.createElement("span");
+        appendedSize.className = QUALITY_SIZE_CLASS;
+        appendedSize.style.cssText = "opacity:0.78;font-size:11px;font-weight:500;margin-left:4px;";
+        appendedSize.textContent = ` (${size})`;
+        label.append(appendedSize);
+    });
+}
+
+function setupQualityMenuSizeSync(
+    response: Awaited<ReturnType<typeof sendRuntimeMessage>>,
+    enabled: boolean,
+) {
+    if (qualityMenuObserver) {
+        qualityMenuObserver.disconnect();
+        qualityMenuObserver = null;
+    }
+
+    clearInjectedQualitySizes();
+
+    if (!enabled) {
+        return;
+    }
+
+    if (!response?.success || !response.data || !("videoFormats" in response.data)) {
+        return;
+    }
+
+    let scheduled = false;
+    const scheduleApply = () => {
+        if (scheduled) return;
+        scheduled = true;
+        requestAnimationFrame(() => {
+            scheduled = false;
+            applyQualitySizes(response.data?.videoFormats || []);
+        });
+    };
+
+    scheduleApply();
+    qualityMenuObserver = new MutationObserver((mutations) => {
+        if (!isQualityMenuMutation(mutations)) return;
+        scheduleApply();
+    });
+    qualityMenuObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+async function syncQualityMenuSetting(showQualitySizesInPlayerMenu?: boolean) {
+    const shouldShowQualitySizes =
+        showQualitySizesInPlayerMenu ??
+        (await getFromSyncCache("showQualitySizesInPlayerMenu")) !== false;
+    setupQualityMenuSizeSync(latestVideoResponse, shouldShowQualitySizes);
+}
 
 async function sendRuntimeMessage(message: { type: string; tag?: string; html?: string }) {
     try {
@@ -28,7 +155,8 @@ async function init(videoTag: string) {
         tag: videoTag,
         html: scriptContent,
     });
-
+    latestVideoResponse = response;
+    await syncQualityMenuSetting();
     await renderPanel(response);
 }
 
@@ -46,6 +174,11 @@ async function handlePageNavigation() {
 
 window.addEventListener("yt-navigate-finish", () => {
     void handlePageNavigation();
+});
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== "sync" || !("showQualitySizesInPlayerMenu" in changes)) return;
+    void syncQualityMenuSetting(changes.showQualitySizesInPlayerMenu.newValue !== false);
 });
 
 void handlePageNavigation();

--- a/tubesize/src/content.ts
+++ b/tubesize/src/content.ts
@@ -1,234 +1,10 @@
 import { extractVideoTag } from "@lib/utils";
 import type { BackgroundResponse } from "@app-types/types";
-import { getFromSyncCache } from "@lib/cache";
 import renderPanel from "./panel";
+import renderPlayerMenu from "./playerMenu";
 
-const QUALITY_SIZE_CLASS = "tubesize-quality-size";
-const SETTINGS_MENU_SELECTOR = ".ytp-settings-menu";
-const SETTINGS_BUTTON_SELECTOR = ".ytp-settings-button";
-let qualityMenuObserver: MutationObserver | null = null;
-let observedSettingsMenu: HTMLElement | null = null;
-let qualityMenuEventAbortController: AbortController | null = null;
-let qualityMenuApplyFrameId: number | null = null;
-let qualityMenuRefreshFrameId: number | null = null;
-let qualityMenuSyncGeneration = 0;
 let latestVideoResponse: BackgroundResponse | undefined;
 let lastTag: string | undefined = undefined;
-
-type VideoFormats = Exclude<BackgroundResponse["data"], null>["videoFormats"];
-
-function parseHeightFromQualityLabel(text: string) {
-    const match = text.match(/\b(\d{3,4})p\b/i);
-    if (!match) return undefined;
-    return parseInt(match[1], 10);
-}
-
-function clearInjectedQualitySizes() {
-    document.querySelectorAll(`.${QUALITY_SIZE_CLASS}`).forEach((el) => {
-        el.remove();
-    });
-}
-
-function cancelQualityMenuFrames() {
-    if (qualityMenuApplyFrameId !== null) {
-        cancelAnimationFrame(qualityMenuApplyFrameId);
-        qualityMenuApplyFrameId = null;
-    }
-
-    if (qualityMenuRefreshFrameId !== null) {
-        cancelAnimationFrame(qualityMenuRefreshFrameId);
-        qualityMenuRefreshFrameId = null;
-    }
-}
-
-function disconnectQualityMenuObserver() {
-    if (!qualityMenuObserver) {
-        observedSettingsMenu = null;
-        return;
-    }
-
-    qualityMenuObserver.disconnect();
-    qualityMenuObserver = null;
-    observedSettingsMenu = null;
-}
-
-function removeQualityMenuListeners() {
-    if (!qualityMenuEventAbortController) return;
-    qualityMenuEventAbortController.abort();
-    qualityMenuEventAbortController = null;
-}
-
-function resetQualityMenuSyncState() {
-    cancelQualityMenuFrames();
-    disconnectQualityMenuObserver();
-    removeQualityMenuListeners();
-    clearInjectedQualitySizes();
-}
-
-function isSettingsMenuOpen(menu: HTMLElement) {
-    const computedStyle = window.getComputedStyle(menu);
-    if (computedStyle.display === "none" || computedStyle.visibility === "hidden") {
-        return false;
-    }
-
-    return menu.getAttribute("aria-hidden") !== "true";
-}
-
-function applyQualitySizes(videoFormats: VideoFormats = []) {
-    const sizeByHeight = new Map<number, string>();
-    videoFormats.forEach((format) => {
-        sizeByHeight.set(format.height, format.size);
-    });
-
-    const qualityLabels = document.querySelectorAll<HTMLElement>(
-        ".ytp-quality-menu .ytp-menuitem-label, .ytp-settings-menu .ytp-menuitem .ytp-menuitem-label",
-    );
-
-    qualityLabels.forEach((label) => {
-        const baseLabel =
-            label.dataset.tubesizeBaseLabel?.trim() ||
-            label.textContent?.replace(/\s+/g, " ").trim() ||
-            "";
-
-        if (!label.dataset.tubesizeBaseLabel) {
-            label.dataset.tubesizeBaseLabel = baseLabel;
-        }
-
-        const height = parseHeightFromQualityLabel(baseLabel);
-        const size = height ? sizeByHeight.get(height) : undefined;
-        const sizeSpan = label.querySelector<HTMLElement>(`.${QUALITY_SIZE_CLASS}`);
-
-        if (!size) {
-            sizeSpan?.remove();
-            return;
-        }
-
-        if (sizeSpan) {
-            const nextText = ` (${size})`;
-            if (sizeSpan.textContent !== nextText) {
-                sizeSpan.textContent = nextText;
-            }
-            return;
-        }
-
-        const appendedSize = document.createElement("span");
-        appendedSize.className = QUALITY_SIZE_CLASS;
-        appendedSize.style.cssText = "opacity:0.78;font-size:11px;font-weight:500;margin-left:4px;";
-        appendedSize.textContent = ` (${size})`;
-        label.append(appendedSize);
-    });
-}
-
-function setupQualityMenuSizeSync(response: BackgroundResponse | undefined, enabled: boolean) {
-    qualityMenuSyncGeneration += 1;
-    const setupGeneration = qualityMenuSyncGeneration;
-    resetQualityMenuSyncState();
-
-    if (!enabled) {
-        return;
-    }
-
-    if (!response?.success || !response.data || !("videoFormats" in response.data)) {
-        return;
-    }
-
-    let scheduled = false;
-    const scheduleApply = () => {
-        if (scheduled) return;
-        scheduled = true;
-        qualityMenuApplyFrameId = requestAnimationFrame(() => {
-            qualityMenuApplyFrameId = null;
-            scheduled = false;
-
-            if (setupGeneration !== qualityMenuSyncGeneration) {
-                return;
-            }
-
-            applyQualitySizes(response.data?.videoFormats || []);
-        });
-    };
-
-    const refreshMenuObserver = () => {
-        const settingsMenu = document.querySelector<HTMLElement>(SETTINGS_MENU_SELECTOR);
-        const shouldObserveMenu = settingsMenu && isSettingsMenuOpen(settingsMenu);
-
-        if (!shouldObserveMenu) {
-            disconnectQualityMenuObserver();
-            return;
-        }
-
-        if (qualityMenuObserver && observedSettingsMenu === settingsMenu) {
-            return;
-        }
-
-        if (qualityMenuObserver) {
-            qualityMenuObserver.disconnect();
-        }
-
-        qualityMenuObserver = new MutationObserver(() => {
-            scheduleApply();
-        });
-        qualityMenuObserver.observe(settingsMenu, {
-            childList: true,
-            subtree: true,
-            characterData: true,
-        });
-        observedSettingsMenu = settingsMenu;
-        scheduleApply();
-    };
-
-    const scheduleRefresh = () => {
-        if (qualityMenuRefreshFrameId !== null) return;
-
-        qualityMenuRefreshFrameId = requestAnimationFrame(() => {
-            qualityMenuRefreshFrameId = null;
-
-            if (setupGeneration !== qualityMenuSyncGeneration) {
-                return;
-            }
-
-            refreshMenuObserver();
-        });
-    };
-
-    scheduleApply();
-    refreshMenuObserver();
-
-    qualityMenuEventAbortController = new AbortController();
-    const { signal } = qualityMenuEventAbortController;
-    document.addEventListener(
-        "click",
-        (event) => {
-            const target = event.target;
-            if (!(target instanceof Element)) return;
-
-            if (
-                observedSettingsMenu ||
-                target.closest(SETTINGS_BUTTON_SELECTOR) ||
-                target.closest(SETTINGS_MENU_SELECTOR)
-            ) {
-                scheduleRefresh();
-            }
-        },
-        { capture: true, signal },
-    );
-    document.addEventListener(
-        "keydown",
-        (event) => {
-            if (event.key === "Escape" && observedSettingsMenu) {
-                scheduleRefresh();
-            }
-        },
-        { signal },
-    );
-}
-
-async function syncQualityMenuSetting(showQualitySizesInPlayerMenu?: boolean) {
-    const shouldShowQualitySizes =
-        showQualitySizesInPlayerMenu ??
-        (await getFromSyncCache("showQualitySizesInPlayerMenu")) !== false;
-    setupQualityMenuSizeSync(latestVideoResponse, shouldShowQualitySizes);
-}
 
 async function sendRuntimeMessage<TResponse = unknown>(message: {
     type: string;
@@ -262,7 +38,7 @@ async function init(videoTag: string) {
         html: scriptContent,
     });
     latestVideoResponse = response;
-    await syncQualityMenuSetting();
+    await renderPlayerMenu(response);
     await renderPanel(response);
 }
 
@@ -276,7 +52,7 @@ async function handlePageNavigation() {
 
     if (!tag) {
         latestVideoResponse = undefined;
-        setupQualityMenuSizeSync(undefined, false);
+        await renderPlayerMenu(undefined, false);
         return;
     }
 
@@ -289,7 +65,10 @@ window.addEventListener("yt-navigate-finish", () => {
 
 chrome.storage.onChanged.addListener((changes, areaName) => {
     if (areaName !== "sync" || !("showQualitySizesInPlayerMenu" in changes)) return;
-    void syncQualityMenuSetting(changes.showQualitySizesInPlayerMenu.newValue !== false);
+    void renderPlayerMenu(
+        latestVideoResponse,
+        changes.showQualitySizesInPlayerMenu.newValue !== false,
+    );
 });
 
 void handlePageNavigation();

--- a/tubesize/src/pages/options.tsx
+++ b/tubesize/src/pages/options.tsx
@@ -7,6 +7,7 @@ import ApiFallbackSetting from "@components/options/apiFallbackSetting";
 import { useState, useEffect } from "react";
 import { getFromSyncCache } from "@lib/cache";
 import PanelSettings from "@components/options/panelOption";
+import QualityMenuSetting from "@components/options/qualityMenuSetting";
 
 export default function Options() {
     const [optionsState, setOptionsState] = useState<Record<any, any>>({});
@@ -46,6 +47,9 @@ export default function Options() {
 
             <div className="section-divider"></div>
             <ApiFallbackSetting />
+
+            <div className="section-divider"></div>
+            <QualityMenuSetting />
 
             <div className="section-divider"></div>
             <PanelSettings />

--- a/tubesize/src/playerMenu.ts
+++ b/tubesize/src/playerMenu.ts
@@ -1,0 +1,230 @@
+import type { BackgroundResponse } from "@app-types/types";
+import { getFromSyncCache } from "@lib/cache";
+
+const QUALITY_SIZE_CLASS = "tubesize-quality-size";
+const SETTINGS_MENU_SELECTOR = ".ytp-settings-menu";
+const SETTINGS_BUTTON_SELECTOR = ".ytp-settings-button";
+
+type VideoFormats = Exclude<BackgroundResponse["data"], null>["videoFormats"];
+
+const syncState: {
+    observer: MutationObserver | null;
+    observedSettingsMenu: HTMLElement | null;
+    eventsController: AbortController | null;
+    applyFrameId: number | null;
+    refreshFrameId: number | null;
+    generation: number;
+} = {
+    observer: null,
+    observedSettingsMenu: null,
+    eventsController: null,
+    applyFrameId: null,
+    refreshFrameId: null,
+    generation: 0,
+};
+
+function getVideoFormats(response: BackgroundResponse | undefined) {
+    if (!response?.success || !response.data || !("videoFormats" in response.data)) {
+        return undefined;
+    }
+
+    return response.data.videoFormats;
+}
+
+function parseHeightFromQualityLabel(text: string) {
+    const match = text.match(/\b(\d{3,4})p\b/i);
+    if (!match) return undefined;
+    return parseInt(match[1], 10);
+}
+
+function clearInjectedQualitySizes() {
+    document.querySelectorAll(`.${QUALITY_SIZE_CLASS}`).forEach((el) => {
+        el.remove();
+    });
+}
+
+function resetQualityMenuSyncState() {
+    if (syncState.applyFrameId !== null) {
+        cancelAnimationFrame(syncState.applyFrameId);
+        syncState.applyFrameId = null;
+    }
+
+    if (syncState.refreshFrameId !== null) {
+        cancelAnimationFrame(syncState.refreshFrameId);
+        syncState.refreshFrameId = null;
+    }
+
+    syncState.observer?.disconnect();
+    syncState.observer = null;
+    syncState.observedSettingsMenu = null;
+
+    syncState.eventsController?.abort();
+    syncState.eventsController = null;
+
+    clearInjectedQualitySizes();
+}
+
+function isSettingsMenuOpen(menu: HTMLElement) {
+    const computedStyle = window.getComputedStyle(menu);
+    if (computedStyle.display === "none" || computedStyle.visibility === "hidden") {
+        return false;
+    }
+
+    return menu.getAttribute("aria-hidden") !== "true";
+}
+
+function applyQualitySizes(videoFormats: VideoFormats = []) {
+    const sizeByHeight = new Map<number, string>();
+    videoFormats.forEach((format) => {
+        sizeByHeight.set(format.height, format.size);
+    });
+
+    const qualityLabels = document.querySelectorAll<HTMLElement>(
+        ".ytp-quality-menu .ytp-menuitem-label, .ytp-settings-menu .ytp-menuitem .ytp-menuitem-label",
+    );
+
+    qualityLabels.forEach((label) => {
+        const baseLabel =
+            label.dataset.tubesizeBaseLabel?.trim() ||
+            label.textContent?.replace(/\s+/g, " ").trim() ||
+            "";
+
+        if (!label.dataset.tubesizeBaseLabel) {
+            label.dataset.tubesizeBaseLabel = baseLabel;
+        }
+
+        const height = parseHeightFromQualityLabel(baseLabel);
+        const size = height ? sizeByHeight.get(height) : undefined;
+        const sizeSpan = label.querySelector<HTMLElement>(`.${QUALITY_SIZE_CLASS}`);
+
+        if (!size) {
+            sizeSpan?.remove();
+            return;
+        }
+
+        if (sizeSpan) {
+            const nextText = ` (${size})`;
+            if (sizeSpan.textContent !== nextText) {
+                sizeSpan.textContent = nextText;
+            }
+            return;
+        }
+
+        const appendedSize = document.createElement("span");
+        appendedSize.className = QUALITY_SIZE_CLASS;
+        appendedSize.style.cssText = "opacity:0.78;font-size:11px;font-weight:500;margin-left:4px;";
+        appendedSize.textContent = ` (${size})`;
+        label.append(appendedSize);
+    });
+}
+
+function setupQualityMenuSizeSync(videoFormats: VideoFormats | undefined, enabled: boolean) {
+    syncState.generation += 1;
+    const setupGeneration = syncState.generation;
+    resetQualityMenuSyncState();
+
+    if (!enabled || !videoFormats?.length) {
+        return;
+    }
+
+    let scheduled = false;
+    const scheduleApply = () => {
+        if (scheduled) return;
+        scheduled = true;
+        syncState.applyFrameId = requestAnimationFrame(() => {
+            syncState.applyFrameId = null;
+            scheduled = false;
+
+            if (setupGeneration !== syncState.generation) {
+                return;
+            }
+
+            applyQualitySizes(videoFormats);
+        });
+    };
+
+    const refreshMenuObserver = () => {
+        const settingsMenu = document.querySelector<HTMLElement>(SETTINGS_MENU_SELECTOR);
+        const shouldObserveMenu = settingsMenu && isSettingsMenuOpen(settingsMenu);
+
+        if (!shouldObserveMenu) {
+            syncState.observer?.disconnect();
+            syncState.observer = null;
+            syncState.observedSettingsMenu = null;
+            return;
+        }
+
+        if (syncState.observer && syncState.observedSettingsMenu === settingsMenu) {
+            return;
+        }
+
+        syncState.observer?.disconnect();
+
+        syncState.observer = new MutationObserver(() => {
+            scheduleApply();
+        });
+        syncState.observer.observe(settingsMenu, {
+            childList: true,
+            subtree: true,
+            characterData: true,
+        });
+        syncState.observedSettingsMenu = settingsMenu;
+        scheduleApply();
+    };
+
+    const scheduleRefresh = () => {
+        if (syncState.refreshFrameId !== null) return;
+
+        syncState.refreshFrameId = requestAnimationFrame(() => {
+            syncState.refreshFrameId = null;
+
+            if (setupGeneration !== syncState.generation) {
+                return;
+            }
+
+            refreshMenuObserver();
+        });
+    };
+
+    scheduleApply();
+    refreshMenuObserver();
+
+    syncState.eventsController = new AbortController();
+    const { signal } = syncState.eventsController;
+    document.addEventListener(
+        "click",
+        (event) => {
+            const target = event.target;
+            if (!(target instanceof Element)) return;
+
+            if (
+                syncState.observedSettingsMenu ||
+                target.closest(SETTINGS_BUTTON_SELECTOR) ||
+                target.closest(SETTINGS_MENU_SELECTOR)
+            ) {
+                scheduleRefresh();
+            }
+        },
+        { capture: true, signal },
+    );
+    document.addEventListener(
+        "keydown",
+        (event) => {
+            if (event.key === "Escape" && syncState.observedSettingsMenu) {
+                scheduleRefresh();
+            }
+        },
+        { signal },
+    );
+}
+
+export default async function renderPlayerMenu(
+    response: BackgroundResponse | undefined,
+    showQualitySizesInPlayerMenu?: boolean,
+) {
+    const shouldShowQualitySizes =
+        showQualitySizesInPlayerMenu ??
+        (await getFromSyncCache("showQualitySizesInPlayerMenu")) !== false;
+
+    setupQualityMenuSizeSync(getVideoFormats(response), shouldShowQualitySizes);
+}


### PR DESCRIPTION
## Summary

This PR adds a new player-menu enhancement that displays video file sizes next to YouTube quality options. It also adds an options-page setting so users can turn the feature on or off.

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/cd4f3f3d-ae36-4f5d-ae62-35037a443025" />

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/943fbd56-061f-4d82-8f6a-34bc77efa640" />


## What changed

- Added logic in the content script to detect the YouTube quality menu and inject size labels
- Kept the injected labels synced with menu updates and navigation changes
- Added a new options section for the quality-menu size setting
- Stored the preference in sync storage and responded to storage updates in real time

## Notes

- The feature uses the video format data already returned by the extension backend
- The setting is enabled by default unless the user disables it