### PR TITLE
highlight current playback quality in popup for youtube and twitch + cache the response for twitch vods

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,6 @@ importers:
       m3u8-parser:
         specifier: ^7.2.0
         version: 7.2.0
-      ms:
-        specifier: ^2.1.3
-        version: 2.1.3
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -3507,7 +3504,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3676,7 +3673,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3811,7 +3808,7 @@ snapshots:
   '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -3827,7 +3824,7 @@ snapshots:
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -4444,7 +4441,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.57.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4454,7 +4451,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4473,7 +4470,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.57.0(eslint@9.39.4)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       eslint: 9.39.4
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -4488,7 +4485,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.0
       '@typescript-eslint/visitor-keys': 8.57.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -4951,6 +4948,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -5121,7 +5122,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -5567,7 +5568,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -5988,7 +5989,7 @@ snapshots:
 
   lighthouse-logger@2.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       marky: 1.3.0
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       filesize:
         specifier: ^11.0.13
         version: 11.0.13
+      humanize-duration:
+        specifier: ^3.33.2
+        version: 3.33.2
       m3u8-parser:
         specifier: ^7.2.0
         version: 7.2.0
@@ -115,6 +118,9 @@ importers:
       '@types/filesize':
         specifier: ^5.0.2
         version: 5.0.2
+      '@types/humanize-duration':
+        specifier: ^3.27.4
+        version: 3.27.4
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -1011,6 +1017,9 @@ packages:
 
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
+
+  '@types/humanize-duration@3.27.4':
+    resolution: {integrity: sha512-yaf7kan2Sq0goxpbcwTQ+8E9RP6HutFBPv74T/IA/ojcHKhuKVlk2YFYyHhWZeLvZPzzLE3aatuQB4h0iqyyUA==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -2057,6 +2066,9 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  humanize-duration@3.33.2:
+    resolution: {integrity: sha512-K7Ny/ULO1hDm2nnhvAY+SJV1skxFb61fd073SG1IWJl+D44ULrruCuTyjHKjBVVcSuTlnY99DKtgEG39CM5QOQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -4345,6 +4357,8 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
+  '@types/humanize-duration@3.27.4': {}
+
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/istanbul-lib-report@3.0.3':
@@ -5427,6 +5441,8 @@ snapshots:
       toidentifier: 1.0.1
 
   human-signals@2.1.0: {}
+
+  humanize-duration@3.33.2: {}
 
   husky@9.1.7: {}
 

--- a/tubesize/manifest.firefox.json
+++ b/tubesize/manifest.firefox.json
@@ -30,7 +30,7 @@
 
     "content_scripts": [
         {
-            "matches": ["https://*.youtube.com/*"],
+            "matches": ["https://*.youtube.com/*", "https://*.twitch.tv/*"],
             "js": ["src/content.js"]
         }
     ],

--- a/tubesize/manifest.json
+++ b/tubesize/manifest.json
@@ -31,7 +31,7 @@
 
     "content_scripts": [
         {
-            "matches": ["https://*.youtube.com/*"],
+            "matches": ["https://*.youtube.com/*", "https://*.twitch.tv/*"],
             "js": ["src/content.ts"]
         }
     ],

--- a/tubesize/package.json
+++ b/tubesize/package.json
@@ -20,7 +20,6 @@
         "filesize": "^11.0.13",
         "humanize-duration": "^3.33.2",
         "m3u8-parser": "^7.2.0",
-        "ms": "^2.1.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "ts-node": "^10.9.2",

--- a/tubesize/package.json
+++ b/tubesize/package.json
@@ -18,6 +18,7 @@
     },
     "dependencies": {
         "filesize": "^11.0.13",
+        "humanize-duration": "^3.33.2",
         "m3u8-parser": "^7.2.0",
         "ms": "^2.1.3",
         "react": "^19.2.0",
@@ -29,6 +30,7 @@
         "@eslint/js": "^9.39.1",
         "@types/chrome": "^0.1.37",
         "@types/filesize": "^5.0.2",
+        "@types/humanize-duration": "^3.27.4",
         "@types/jest": "^30.0.0",
         "@types/m3u8-parser": "^7.2.6",
         "@types/ms": "^2.1.0",

--- a/tubesize/src/background.ts
+++ b/tubesize/src/background.ts
@@ -91,7 +91,9 @@ async function handleTwitch(
                 data: filteredM3U8Data,
                 vodId: message.vodId,
             };
-            await saveToStorage(message.vodId, response);
+            if (filteredM3U8Data.length > 0) {
+                await saveToStorage(message.vodId, response);
+            }
 
             return sendResponse({
                 success: true,

--- a/tubesize/src/background.ts
+++ b/tubesize/src/background.ts
@@ -6,7 +6,7 @@ import type {
     FrontEndMessage,
     TwitchMessage,
 } from "@app-types/types";
-import { getFromStorage, saveToStorage } from "@lib/cache";
+import { clearLocalStorage, getFromStorage, saveToStorage } from "@lib/cache";
 import { addBadge, clearBadge } from "@/badge";
 import {
     extractYtInitial,
@@ -176,3 +176,9 @@ async function handleYoutube(
         });
     }
 }
+
+chrome.runtime.onInstalled.addListener(async (details) => {
+    if (details.reason === "install" || details.reason === "update") {
+        await clearLocalStorage();
+    }
+});

--- a/tubesize/src/background.ts
+++ b/tubesize/src/background.ts
@@ -70,6 +70,16 @@ async function handleTwitch(
                 twitchData,
             });
         } else if (message.type === "twitchVod") {
+            const cached = await getFromStorage("twitch", message.vodId);
+            if (cached) {
+                return sendResponse({
+                    success: true,
+                    twitchData: cached.response,
+                    cached: true,
+                    createdAt: cached.createdAt,
+                });
+            }
+
             const twitchToken = await getTwitchToken(message);
             if (!twitchToken) {
                 throw new Error("Failed to retrieve Twitch token");
@@ -77,9 +87,15 @@ async function handleTwitch(
             const m3u8Data = await getM3U8Data(twitchToken, message);
             const filteredM3U8Data = filterM3U8Data(m3u8Data);
 
+            const response = {
+                data: filteredM3U8Data,
+                vodId: message.vodId,
+            };
+            await saveToStorage(message.vodId, response);
+
             return sendResponse({
                 success: true,
-                twitchData: { data: filteredM3U8Data, vodId: message.vodId },
+                twitchData: response,
             });
         } else {
             throw new Error("No channel name or VOD ID provided");
@@ -111,7 +127,7 @@ async function handleYoutube(
     }
     clearBadge(message.tabId);
 
-    const cached = await getFromStorage(videoTag);
+    const cached = await getFromStorage("youtube", videoTag);
     if (cached) {
         addBadge(message.tabId);
         return sendResponse({

--- a/tubesize/src/background.ts
+++ b/tubesize/src/background.ts
@@ -87,9 +87,10 @@ async function handleTwitch(
             const m3u8Data = await getM3U8Data(twitchToken, message);
             const filteredM3U8Data = filterM3U8Data(m3u8Data);
 
-            const response = {
+            const response: TwitchData = {
                 data: filteredM3U8Data,
                 vodId: message.vodId,
+                durationSeconds: twitchToken.durationSeconds,
             };
             if (filteredM3U8Data.length > 0) {
                 await saveToStorage(message.vodId, response);

--- a/tubesize/src/components/header.tsx
+++ b/tubesize/src/components/header.tsx
@@ -17,16 +17,17 @@ function getYoutubeDuration(youtubeData?: YoutubeBackgroundResponse | null): str
 }
 
 function getTwitchTitle(twitchData?: TwitchBackgroundResponse | null): string {
-    if (!twitchData?.twitchData) {
+    const data = twitchData?.twitchData;
+
+    if (!data) {
         return "Twitch";
     }
-    if ("channelName" in twitchData?.twitchData) {
-        return twitchData.twitchData.channelName;
+
+    if ("channelName" in data) {
+        return data.channelName;
     }
-    if ("vodId" in twitchData.twitchData) {
-        return "Twitch Video";
-    }
-    return "Twitch";
+
+    return "Twitch Video";
 }
 
 function getTwitchDuration(twitchData?: TwitchBackgroundResponse | null): string | undefined {

--- a/tubesize/src/components/header.tsx
+++ b/tubesize/src/components/header.tsx
@@ -8,40 +8,29 @@ interface Props {
     setUseOptionsPage: (useOptionsPage: boolean) => void;
 }
 
-function getTitle(
-    pageType: Props["pageType"],
-    youtubeData?: YoutubeBackgroundResponse | null,
-    twitchData?: TwitchBackgroundResponse | null,
-): string {
-    if (pageType === "youtube") {
-        return youtubeData?.data?.title ?? "TubeSize";
-    }
-    if (pageType === "twitch") {
-        const data = twitchData?.twitchData;
-        if (!data) return "Twitch";
-        return "channelName" in data ? (data.channelName ?? "Twitch") : "Twitch Video";
-    }
-    return "TubeSize";
+function getYoutubeTitle(isLive: boolean | undefined): string {
+    return isLive ? "Live Stream" : "YouTube Video";
 }
 
-function getDuration(
-    pageType: Props["pageType"],
-    youtubeData?: YoutubeBackgroundResponse | null,
-    twitchData?: TwitchBackgroundResponse | null,
-): string | undefined {
-    if (pageType === "youtube") {
-        return youtubeData?.data?.isLive ? "Live" : youtubeData?.data?.durationMinutes;
+function getYoutubeDuration(youtubeData?: YoutubeBackgroundResponse | null): string | undefined {
+    return youtubeData?.data?.durationMinutes;
+}
+
+function getTwitchTitle(isLive: boolean | undefined): string {
+    return isLive ? "Live Stream" : "Twitch Video";
+}
+
+function getTwitchDuration(twitchData?: TwitchBackgroundResponse | null): string | undefined {
+    const data = twitchData?.twitchData;
+
+    if (!data || "channelName" in data) {
+        return undefined;
     }
-    if (pageType === "twitch") {
-        const data = twitchData?.twitchData;
-        if (data && "durationSeconds" in data && data.durationSeconds) {
-            return humanizeDuration(data.durationSeconds * 1000);
-        } else if (data && "channelName" in data) {
-            return "Live";
-        } else {
-            return undefined;
-        }
+
+    if (data.durationSeconds) {
+        return humanizeDuration(data.durationSeconds * 1000);
     }
+
     return undefined;
 }
 
@@ -51,8 +40,20 @@ export default function Header({
     twitchData,
     setUseOptionsPage,
 }: Props) {
-    const title = getTitle(pageType, youtubeData, twitchData);
-    const duration = getDuration(pageType, youtubeData, twitchData);
+    const isLive =
+        (pageType === "youtube" && youtubeData?.data?.isLive) ||
+        (pageType === "twitch" && twitchData?.twitchData && "channelName" in twitchData.twitchData);
+
+    let title = "TubeSize";
+    let duration: string | undefined;
+
+    if (pageType === "youtube") {
+        title = getYoutubeTitle(isLive);
+        duration = getYoutubeDuration(youtubeData);
+    } else if (pageType === "twitch") {
+        title = getTwitchTitle(isLive);
+        duration = getTwitchDuration(twitchData);
+    }
 
     return (
         <div className="header">
@@ -62,11 +63,15 @@ export default function Header({
             >
                 {title}
             </div>
-            {duration && (
+            {isLive ? (
+                <span className="live-indicator" id="duration-display">
+                    Live
+                </span>
+            ) : duration ? (
                 <span className="duration" id="duration-display">
                     {duration}
                 </span>
-            )}
+            ) : null}
             <button id="optionsBtn" onClick={() => setUseOptionsPage(true)}>
                 Options
             </button>

--- a/tubesize/src/components/header.tsx
+++ b/tubesize/src/components/header.tsx
@@ -1,4 +1,5 @@
 import type { TwitchBackgroundResponse, YoutubeBackgroundResponse } from "@app-types/types";
+import { humanizeDuration } from "@lib/utils";
 
 interface Props {
     pageType?: "youtube" | "twitch" | "default";
@@ -23,6 +24,27 @@ function getTitle(
     return "TubeSize";
 }
 
+function getDuration(
+    pageType: Props["pageType"],
+    youtubeData?: YoutubeBackgroundResponse | null,
+    twitchData?: TwitchBackgroundResponse | null,
+): string | undefined {
+    if (pageType === "youtube") {
+        return youtubeData?.data?.isLive ? "Live" : youtubeData?.data?.durationMinutes;
+    }
+    if (pageType === "twitch") {
+        const data = twitchData?.twitchData;
+        if (data && "durationSeconds" in data && data.durationSeconds) {
+            return humanizeDuration(data.durationSeconds * 1000);
+        } else if (data && "channelName" in data) {
+            return "Live";
+        } else {
+            return undefined;
+        }
+    }
+    return undefined;
+}
+
 export default function Header({
     pageType = "default",
     youtubeData,
@@ -30,11 +52,7 @@ export default function Header({
     setUseOptionsPage,
 }: Props) {
     const title = getTitle(pageType, youtubeData, twitchData);
-
-    const duration =
-        pageType === "youtube" && !youtubeData?.data?.isLive
-            ? youtubeData?.data?.durationMinutes
-            : undefined;
+    const duration = getDuration(pageType, youtubeData, twitchData);
 
     return (
         <div className="header">
@@ -44,7 +62,7 @@ export default function Header({
             >
                 {title}
             </div>
-            {pageType === "youtube" && (
+            {duration && (
                 <span className="duration" id="duration-display">
                     {duration}
                 </span>

--- a/tubesize/src/components/header.tsx
+++ b/tubesize/src/components/header.tsx
@@ -8,16 +8,25 @@ interface Props {
     setUseOptionsPage: (useOptionsPage: boolean) => void;
 }
 
-function getYoutubeTitle(isLive: boolean | undefined): string {
-    return isLive ? "Live Stream" : "YouTube Video";
+function getYoutubeTitle(youtubeData?: YoutubeBackgroundResponse | null): string {
+    return youtubeData?.data?.title || "YouTube Video";
 }
 
 function getYoutubeDuration(youtubeData?: YoutubeBackgroundResponse | null): string | undefined {
     return youtubeData?.data?.durationMinutes;
 }
 
-function getTwitchTitle(isLive: boolean | undefined): string {
-    return isLive ? "Live Stream" : "Twitch Video";
+function getTwitchTitle(twitchData?: TwitchBackgroundResponse | null): string {
+    if (!twitchData?.twitchData) {
+        return "Twitch";
+    }
+    if ("channelName" in twitchData?.twitchData) {
+        return twitchData.twitchData.channelName;
+    }
+    if ("vodId" in twitchData.twitchData) {
+        return "Twitch Video";
+    }
+    return "Twitch";
 }
 
 function getTwitchDuration(twitchData?: TwitchBackgroundResponse | null): string | undefined {
@@ -48,10 +57,10 @@ export default function Header({
     let duration: string | undefined;
 
     if (pageType === "youtube") {
-        title = getYoutubeTitle(isLive);
+        title = getYoutubeTitle(youtubeData);
         duration = getYoutubeDuration(youtubeData);
     } else if (pageType === "twitch") {
-        title = getTwitchTitle(isLive);
+        title = getTwitchTitle(twitchData);
         duration = getTwitchDuration(twitchData);
     }
 

--- a/tubesize/src/components/twitchFormat.tsx
+++ b/tubesize/src/components/twitchFormat.tsx
@@ -1,9 +1,16 @@
 import type { TwitchData } from "@/types/types";
 import { filesize } from "filesize";
 
-export default function TwitchFormat({ item }: { item: NonNullable<TwitchData["data"]>[number] }) {
+interface Props {
+    item: NonNullable<TwitchData["data"]>[number];
+    currentQuality?: number;
+}
+
+export default function TwitchFormat({ item, currentQuality }: Props) {
+    const className = item.resolution === currentQuality ? "format-item current" : "format-item";
+
     return (
-        <div className="format-item">
+        <div className={className}>
             <div className="format-height"> {item.resolution} </div>
             <div className="format-size">
                 <span>{"~" + filesize((item.bandwidth / 8) * 60 * 60) + "/hour"}</span>

--- a/tubesize/src/components/youtubeFormat.tsx
+++ b/tubesize/src/components/youtubeFormat.tsx
@@ -4,11 +4,18 @@ interface Props {
     item: NonNullable<YoutubeBackgroundResponse["data"]>["videoFormats"][number];
     isLive: boolean | undefined;
     isShorts: boolean | undefined;
+    currentQuality: number | undefined;
 }
 
-export default function YoutubeFormat({ item, isLive = false, isShorts = false }: Props) {
+export default function YoutubeFormat({
+    item,
+    isLive = false,
+    isShorts = false,
+    currentQuality,
+}: Props) {
+    const className = item?.height === currentQuality ? "format-item current" : "format-item";
     return (
-        <div className="format-item">
+        <div className={className}>
             <div className="format-height"> {item.height} </div>
             <div className="format-size">
                 <span>{!isLive ? item.sizeMB : item.sizeMB + "/hour"}</span>

--- a/tubesize/src/content.ts
+++ b/tubesize/src/content.ts
@@ -66,9 +66,9 @@ chrome.runtime.onMessage.addListener(
 );
 
 async function getCurrentResolution() {
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 5; i++) {
         const video = document.querySelector("video");
-        if (video) {
+        if (video && video.videoHeight > 0) {
             return video.videoHeight;
         }
         await new Promise((resolve) => setTimeout(resolve, 500));

--- a/tubesize/src/content.ts
+++ b/tubesize/src/content.ts
@@ -1,4 +1,4 @@
-import { extractVideoTag } from "@lib/utils";
+import { extractVideoTag, isYoutubePage } from "@lib/utils";
 import type { FrontEndMessage } from "./types/types";
 
 async function sendRuntimeMessage(message: FrontEndMessage) {
@@ -15,7 +15,7 @@ async function sendRuntimeMessage(message: FrontEndMessage) {
     }
 }
 
-async function init(videoTag: string) {
+async function initYoutube(videoTag: string) {
     const scriptsArray = Array.from(document.scripts);
     const ytInitialPlayerResponse = scriptsArray.find((script) => {
         return script.textContent?.includes("ytInitialPlayerResponse");
@@ -32,6 +32,10 @@ async function init(videoTag: string) {
 
 let lastTag: string | undefined = undefined;
 async function handlePageNavigation() {
+    if (!isYoutubePage(window.location.href)) {
+        return;
+    }
+
     await sendRuntimeMessage({ type: "clearBadge" });
     const url = window.location.href;
     const tag = extractVideoTag(url);
@@ -39,11 +43,36 @@ async function handlePageNavigation() {
     if (lastTag === tag) return;
     lastTag = tag;
 
-    if (tag) await init(tag);
+    if (tag) await initYoutube(tag);
 }
 
-window.addEventListener("yt-navigate-finish", () => {
-    void handlePageNavigation();
-});
+if (isYoutubePage(window.location.href)) {
+    window.addEventListener("yt-navigate-finish", () => {
+        void handlePageNavigation();
+    });
+}
+
+chrome.runtime.onMessage.addListener(
+    (message: { type: string }, _sender: chrome.runtime.MessageSender, sendResponse) => {
+        if (message.type !== "getCurrentResolution") return;
+
+        void getCurrentResolution().then((resolution) => {
+            sendResponse(resolution);
+        });
+
+        return true;
+    },
+);
+
+async function getCurrentResolution() {
+    for (let i = 0; i < 10; i++) {
+        const video = document.querySelector("video");
+        if (video) {
+            return video.videoHeight;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    return undefined;
+}
 
 void handlePageNavigation();

--- a/tubesize/src/content.ts
+++ b/tubesize/src/content.ts
@@ -32,11 +32,12 @@ async function initYoutube(videoTag: string) {
 
 let lastTag: string | undefined = undefined;
 async function handlePageNavigation() {
+    await sendRuntimeMessage({ type: "clearBadge" });
+
     if (!isYoutubePage(window.location.href)) {
         return;
     }
 
-    await sendRuntimeMessage({ type: "clearBadge" });
     const url = window.location.href;
     const tag = extractVideoTag(url);
 

--- a/tubesize/src/lib/cache.ts
+++ b/tubesize/src/lib/cache.ts
@@ -65,8 +65,10 @@ export async function saveToStorage(tag: string, response: HumanizedFormat | Twi
         createdAt: new Date().toISOString(),
     };
 
+    const prefix = "videoFormats" in response ? "youtube" : "twitch";
+
     await setToLocalCache({
-        [tag]: dataToStore,
+        [`${prefix}:${tag}`]: dataToStore,
     });
 }
 
@@ -80,17 +82,17 @@ export async function getFromStorage(
 ): Promise<StorageData<TwitchData> | null>;
 
 export async function getFromStorage(
-    _target: "youtube" | "twitch",
+    target: "youtube" | "twitch",
     tag: string,
 ): Promise<StorageData<HumanizedFormat | TwitchData> | null> {
-    const data = await getFromLocalCache(tag);
+    const data = await getFromLocalCache(`${target}:${tag}`);
     const item = data as StorageData<HumanizedFormat | TwitchData> | undefined;
 
     if (!item) return null;
 
     // Tag expired
     if (item.expiry && item.expiry < Date.now()) {
-        await removeFromLocalCache(tag);
+        await removeFromLocalCache(`${target}:${tag}`);
         return null;
     }
 

--- a/tubesize/src/lib/cache.ts
+++ b/tubesize/src/lib/cache.ts
@@ -70,9 +70,21 @@ export async function saveToStorage(tag: string, response: HumanizedFormat | Twi
     });
 }
 
-export async function getFromStorage(tag: string): Promise<StorageData | null> {
+export async function getFromStorage(
+    target: "youtube",
+    tag: string,
+): Promise<StorageData<HumanizedFormat> | null>;
+export async function getFromStorage(
+    target: "twitch",
+    tag: string,
+): Promise<StorageData<TwitchData> | null>;
+
+export async function getFromStorage(
+    _target: "youtube" | "twitch",
+    tag: string,
+): Promise<StorageData<HumanizedFormat | TwitchData> | null> {
     const data = await getFromLocalCache(tag);
-    const item = data as StorageData | undefined;
+    const item = data as StorageData<HumanizedFormat | TwitchData> | undefined;
 
     if (!item) return null;
 

--- a/tubesize/src/lib/constants.ts
+++ b/tubesize/src/lib/constants.ts
@@ -33,6 +33,48 @@ const CONFIG = {
     VIDEO_ID_REGEX: /^[a-zA-Z0-9_-]{11}$/,
     YT_INITIAL_PLAYER_REGEX: /ytInitialPlayerResponse\s*=\s*(\{.+?\});/s,
     CACHE_JUST_NOW_THRESHOLD: 5000,
+    TWITCH_GQL_GRAPHQL_QUERY: `
+        query PlaybackAccessToken_Template(
+        $login: String!,
+        $isLive: Boolean!,
+        $vodID: ID!,
+        $isVod: Boolean!,
+        $playerType: String!,
+        $platform: String!
+        ) {
+        streamPlaybackAccessToken(
+            channelName: $login,
+            params: {
+            platform: $platform,
+            playerBackend: "mediaplayer",
+            playerType: $playerType
+            }
+        ) @include(if: $isLive) {
+            value
+            signature
+            authorization {
+            isForbidden
+            forbiddenReasonCode
+            }
+            __typename
+        }
+        videoPlaybackAccessToken(
+            id: $vodID,
+            params: {
+            platform: $platform,
+            playerBackend: "mediaplayer",
+            playerType: $playerType
+            }
+        ) @include(if: $isVod) {
+            value
+            signature
+            __typename
+        }
+        video(id: $vodID) @include(if: $isVod) {
+            lengthSeconds
+        }
+    }
+`,
 } as const;
 
 export default CONFIG;

--- a/tubesize/src/lib/twitch.ts
+++ b/tubesize/src/lib/twitch.ts
@@ -1,5 +1,6 @@
 import type { TwitchData, TwitchMessage, TwitchTokenData } from "@/types/types";
 import { Parser } from "m3u8-parser";
+import CONFIG from "@lib/constants";
 
 export async function getClientId(message: TwitchMessage): Promise<string> {
     const url =
@@ -28,7 +29,7 @@ export async function getTwitchToken(message: TwitchMessage): Promise<TwitchToke
             "Content-Type": "application/json",
         };
         const body = {
-            query: 'query PlaybackAccessToken_Template($login: String!, $isLive: Boolean!, $vodID: ID!, $isVod: Boolean!, $playerType: String!, $platform: String!) { streamPlaybackAccessToken(channelName: $login, params: {platform: $platform, playerBackend: "mediaplayer", playerType: $playerType}) @include(if: $isLive) { value signature authorization { isForbidden forbiddenReasonCode } __typename } videoPlaybackAccessToken(id: $vodID, params: {platform: $platform, playerBackend: "mediaplayer", playerType: $playerType}) @include(if: $isVod) { value signature __typename }}',
+            query: CONFIG.TWITCH_GQL_GRAPHQL_QUERY,
             variables: {
                 login: message.type === "twitchLive" ? message.channelName : "",
                 isLive: message.type === "twitchLive",
@@ -60,6 +61,7 @@ export async function getTwitchToken(message: TwitchMessage): Promise<TwitchToke
             signature:
                 data.data.streamPlaybackAccessToken?.signature ||
                 data.data.videoPlaybackAccessToken.signature,
+            durationSeconds: data.data.video?.lengthSeconds,
         };
     } catch (error) {
         console.error("Failed to get Twitch token:", error);

--- a/tubesize/src/lib/utils.ts
+++ b/tubesize/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { getFromSyncCache } from "@lib/cache";
 import CONFIG from "@lib/constants";
+import humanize from "humanize-duration";
 
 export function isYoutubePage(url: string): boolean {
     try {
@@ -155,7 +156,6 @@ export async function fetchAndRetry(
     throw new Error(`Failed after ${maxRetries} tries, last error: ${lastError}`);
 }
 
-import humanize from "humanize-duration";
 export const humanizeDuration = humanize.humanizer({
     language: "shortEn",
     round: true,

--- a/tubesize/src/lib/utils.ts
+++ b/tubesize/src/lib/utils.ts
@@ -154,3 +154,22 @@ export async function fetchAndRetry(
     }
     throw new Error(`Failed after ${maxRetries} tries, last error: ${lastError}`);
 }
+
+import humanize from "humanize-duration";
+export const humanizeDuration = humanize.humanizer({
+    language: "shortEn",
+    round: true,
+    largest: 2,
+    languages: {
+        shortEn: {
+            y: () => "y",
+            mo: () => "mo",
+            w: () => "w",
+            d: () => "d",
+            h: () => "h",
+            m: () => "m",
+            s: () => "s",
+            ms: () => "ms",
+        },
+    },
+});

--- a/tubesize/src/lib/youtube.ts
+++ b/tubesize/src/lib/youtube.ts
@@ -1,7 +1,6 @@
 import { filesize } from "filesize";
 import type { HumanizedFormat, RawData, RawFormat } from "@app-types/types";
-import ms from "ms";
-import { fetchAndRetry } from "@lib/utils";
+import { fetchAndRetry, humanizeDuration } from "@lib/utils";
 import CONFIG from "@lib/constants";
 
 export function sizePerMinute(
@@ -30,7 +29,7 @@ export function humanizeData(formats: RawFormat): HumanizedFormat {
     return {
         id: formats.id,
         title: formats.title,
-        durationMinutes: ms(formats.durationSeconds * 1000),
+        durationMinutes: humanizeDuration(formats.durationSeconds * 1000),
         videoFormats: humanizedVideoFormats,
         isLive: formats.isLive,
     };

--- a/tubesize/src/pages/popup.tsx
+++ b/tubesize/src/pages/popup.tsx
@@ -14,9 +14,9 @@ import {
     extractTwitchChannelName,
     isTwitchVod,
     extractTwitchVodId,
+    humanizeDuration,
 } from "@lib/utils";
 import { getFromSyncCache } from "@lib/cache";
-import ms from "ms";
 import Options from "@pages/options";
 import CONFIG from "@lib/constants";
 import Header from "@components/header";
@@ -75,7 +75,7 @@ function getCachedAgo(createdAt: string | undefined) {
     if (timeInMs < CONFIG.CACHE_JUST_NOW_THRESHOLD) {
         return "Cached just now";
     } else {
-        const timeAgo = ms(timeInMs, { long: true });
+        const timeAgo = humanizeDuration(timeInMs);
         return `Cached ${timeAgo} ago`;
     }
 }

--- a/tubesize/src/pages/popup.tsx
+++ b/tubesize/src/pages/popup.tsx
@@ -34,10 +34,9 @@ async function getCurrentQuality(tabId: number): Promise<number | undefined> {
                 const errorMessage = chrome.runtime.lastError.message || "";
 
                 if (errorMessage.includes("Receiving end does not exist")) {
-                    console.error(errorMessage);
                     return resolve(undefined);
                 }
-                return reject(undefined);
+                return reject(new Error(errorMessage || "Failed to get current resolution"));
             }
             resolve(response);
         });

--- a/tubesize/src/pages/popup.tsx
+++ b/tubesize/src/pages/popup.tsx
@@ -198,7 +198,6 @@ export default function Popup() {
                 setCurrentQuality(quality);
             } catch (err: any) {
                 console.error(err);
-                setError(err);
             }
         })();
     }, []);

--- a/tubesize/src/pages/popup.tsx
+++ b/tubesize/src/pages/popup.tsx
@@ -27,10 +27,24 @@ async function getTab() {
     return await chrome.tabs.query({ active: true, currentWindow: true });
 }
 
-// async function sendMessageToBackground(message: YoutubeMessage): Promise<YoutubeBackgroundResponse>;
+async function getCurrentQuality(tabId: number): Promise<number | undefined> {
+    return new Promise((resolve, reject) => {
+        chrome.tabs.sendMessage(tabId, { type: "getCurrentResolution" }, (response) => {
+            if (chrome.runtime.lastError) {
+                const errorMessage = chrome.runtime.lastError.message || "";
 
-// async function sendMessageToBackground(message: TwitchMessage): Promise<TwitchBackgroundResponse>;
+                if (errorMessage.includes("Receiving end does not exist")) {
+                    resolve(undefined);
+                    return;
+                }
 
+                reject(new Error(errorMessage));
+                return;
+            }
+            resolve(response);
+        });
+    });
+}
 type MessageResponseMap = {
     youtubeVideo: YoutubeBackgroundResponse;
     twitchVod: TwitchBackgroundResponse;
@@ -82,6 +96,7 @@ export default function Popup() {
     const [useOptionsPage, setUseOptionsPage] = useState(false);
     const [enabledOptions, setEnabledOptions] = useState<string[]>([]);
     const [error, setError] = useState<Error | null>(null);
+    const [currentQuality, setCurrentQuality] = useState<number | undefined>(undefined);
 
     useEffect(() => {
         (async () => {
@@ -130,6 +145,11 @@ export default function Popup() {
                         });
                         if (!response.success) throw new Error(response.message);
                         setTwitchData(response);
+                        setCache(
+                            response.cached
+                                ? getCachedAgo(response.createdAt) || "Cached just now"
+                                : undefined,
+                        );
                         return;
                     }
                     const channelName = extractTwitchChannelName(url);
@@ -162,6 +182,20 @@ export default function Popup() {
                     return allOptions[option] ?? true;
                 });
                 setEnabledOptions(enabledOptions);
+            } catch (err: any) {
+                console.error(err);
+                setError(err);
+            }
+        })();
+    }, []);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const [tab] = await getTab();
+                if (!tab?.id) return;
+                const quality = await getCurrentQuality(tab.id!);
+                setCurrentQuality(quality);
             } catch (err: any) {
                 console.error(err);
                 setError(err);
@@ -203,6 +237,7 @@ export default function Popup() {
                                     item={item}
                                     isLive={youtubeData.data?.isLive}
                                     isShorts={youtubeData.isShorts}
+                                    currentQuality={currentQuality}
                                 />
                             );
                         })
@@ -211,7 +246,13 @@ export default function Popup() {
                     twitchData?.twitchData?.data
                         .sort((a, b) => b.bandwidth - a.bandwidth)
                         .map((item) => {
-                            return <TwitchFormat key={item.resolution} item={item} />;
+                            return (
+                                <TwitchFormat
+                                    key={item.resolution}
+                                    item={item}
+                                    currentQuality={currentQuality}
+                                />
+                            );
                         })}
             </div>
         </>

--- a/tubesize/src/pages/popup.tsx
+++ b/tubesize/src/pages/popup.tsx
@@ -34,12 +34,10 @@ async function getCurrentQuality(tabId: number): Promise<number | undefined> {
                 const errorMessage = chrome.runtime.lastError.message || "";
 
                 if (errorMessage.includes("Receiving end does not exist")) {
-                    resolve(undefined);
-                    return;
+                    console.error(errorMessage);
+                    return resolve(undefined);
                 }
-
-                reject(new Error(errorMessage));
-                return;
+                return reject(undefined);
             }
             resolve(response);
         });

--- a/tubesize/src/styles/popup.css
+++ b/tubesize/src/styles/popup.css
@@ -94,11 +94,11 @@ body {
     border: 1px solid transparent;
 }
 .format-item.current {
-    background: rgba(172, 60, 75, 0.452);
+    background: rgba(220, 38, 38, 0.22);
 }
 .format-item.current:hover {
-    background: rgba(172, 60, 75, 0.6);
-    border-color: #690b0b;
+    background: rgba(220, 38, 38, 0.3);
+    border-color: rgba(239, 68, 68, 0.42);
 }
 .format-item:hover {
     background: rgba(255, 255, 255, 0.08);
@@ -112,13 +112,15 @@ body {
 }
 .format-size {
     display: flex;
-    justify-content: right;
     flex-direction: column;
+    align-items: flex-end;
+    text-align: right;
     color: #bbb;
     font-weight: 500;
     font-size: 13px;
 }
 .format-size-per-minute {
+    align-self: flex-end;
     font-size: 11px;
     color: #7dd3fc;
 }

--- a/tubesize/src/styles/popup.css
+++ b/tubesize/src/styles/popup.css
@@ -94,14 +94,7 @@ body {
     border: 1px solid transparent;
 }
 .format-item.current {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 8px 10px;
     background: rgba(172, 60, 75, 0.452);
-    border-radius: 6px;
-    cursor: pointer;
-    border: 1px solid transparent;
 }
 .format-item.current:hover {
     background: rgba(172, 60, 75, 0.6);

--- a/tubesize/src/styles/popup.css
+++ b/tubesize/src/styles/popup.css
@@ -36,6 +36,11 @@ body {
     white-space: nowrap;
     flex-shrink: 0;
 }
+.live-indicator {
+    font-size: 14px;
+    color: #bd0202e3;
+    font-weight: bolder;
+}
 #optionsBtn {
     font-size: 12px;
     padding: 4px 6px;
@@ -126,7 +131,7 @@ body {
 }
 .cached-note {
     font-size: 11px;
-    color: #888;
+    color: #949494;
     text-align: center;
     font-style: italic;
 }

--- a/tubesize/src/styles/popup.css
+++ b/tubesize/src/styles/popup.css
@@ -93,6 +93,20 @@ body {
     cursor: pointer;
     border: 1px solid transparent;
 }
+.format-item.current {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 10px;
+    background: rgba(172, 60, 75, 0.452);
+    border-radius: 6px;
+    cursor: pointer;
+    border: 1px solid transparent;
+}
+.format-item.current:hover {
+    background: rgba(172, 60, 75, 0.6);
+    border-color: #690b0b;
+}
 .format-item:hover {
     background: rgba(255, 255, 255, 0.08);
     border-color: #690b0b;

--- a/tubesize/src/styles/popup.css
+++ b/tubesize/src/styles/popup.css
@@ -120,7 +120,7 @@ body {
 }
 .format-size-per-minute {
     font-size: 11px;
-    color: #888;
+    color: #7dd3fc;
 }
 .cached-note {
     font-size: 11px;

--- a/tubesize/src/types/types.ts
+++ b/tubesize/src/types/types.ts
@@ -65,6 +65,7 @@ export type YoutubeBackgroundResponse = {
 export type TwitchTokenData = {
     value: string;
     signature: string;
+    durationSeconds?: number;
 };
 
 type TwitchStreamInfo = {
@@ -75,7 +76,7 @@ type TwitchStreamInfo = {
 
 export type TwitchData =
     | { data: TwitchStreamInfo[]; channelName: string }
-    | { data: TwitchStreamInfo[]; vodId: string };
+    | { data: TwitchStreamInfo[]; vodId: string; durationSeconds: number | undefined };
 
 export type TwitchBackgroundResponse = {
     success: boolean;

--- a/tubesize/src/types/types.ts
+++ b/tubesize/src/types/types.ts
@@ -47,8 +47,8 @@ export type HumanizedFormat = {
     }[];
 };
 
-export type StorageData = {
-    response: HumanizedFormat;
+export type StorageData<T extends HumanizedFormat | TwitchData> = {
+    response: T;
     expiry?: number;
     createdAt?: string;
 };
@@ -81,6 +81,8 @@ export type TwitchBackgroundResponse = {
     success: boolean;
     twitchData?: TwitchData;
     message?: string;
+    cached?: boolean;
+    createdAt?: string;
 };
 
 export type FrontEndMessage =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extension now runs on Twitch pages in addition to YouTube.
  * Detects current playback quality and surfaces it to the UI.

* **UI Improvements**
  * Highlights the currently playing format.
  * Shows human-friendly durations for Twitch and YouTube (including live indicator).

* **Chores**
  * Namespaced caching with improved storage behavior; storage cleared on install/update.
  * Added a duration-formatting dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->