### PR TITLE
Increase the accuracy of twitch live streams size estimation & refactor HLS

### DIFF
--- a/tubesize/manifest.json
+++ b/tubesize/manifest.json
@@ -20,9 +20,9 @@
     "host_permissions": [
         "https://*.youtube.com/*",
         "https://*.twitch.tv/*",
-        "https://usher.ttvnw.net/api/v2/channel/hls/*",
-        "https://gql.twitch.tv/gql/*",
-        "https://*.playlist.ttvnw.net/v1/playlist",
+        "https://gql.twitch.tv/*",
+        "https://usher.ttvnw.net/*",
+        "https://*.playlist.ttvnw.net/v1/playlist/*",
         "https://*.cloudfront.hls.ttvnw.net/v1/segment/*",
         "https://*.kick.com/*",
         "https://*.playback.live-video.net/*",

--- a/tubesize/manifest.json
+++ b/tubesize/manifest.json
@@ -22,6 +22,8 @@
         "https://*.twitch.tv/*",
         "https://usher.ttvnw.net/api/v2/channel/hls/*",
         "https://gql.twitch.tv/gql/*",
+        "https://*.playlist.ttvnw.net/v1/playlist",
+        "https://*.cloudfront.hls.ttvnw.net/v1/segment/*",
         "https://*.kick.com/*",
         "https://*.playback.live-video.net/*",
         "https://*.cloudfront.hls.live-video.net/v1/*"

--- a/tubesize/src/background.ts
+++ b/tubesize/src/background.ts
@@ -1,7 +1,6 @@
 import type {
     YoutubeBackgroundResponse,
     TwitchBackgroundResponse,
-    TwitchData,
     YoutubeMessage,
     FrontEndMessage,
     TwitchMessage,
@@ -9,13 +8,8 @@ import type {
 } from "@app-types/types";
 import { clearLocalCache, clearSyncCache, getFromStorage, saveToStorage } from "@lib/cache";
 import { addBadge, clearBadge } from "@/badge";
-import {
-    extractYtInitial,
-    fetchHTMLPage,
-    parseDataFromYtInitial,
-    humanizeData,
-} from "@lib/youtube";
-import { getTwitchMasterM3u8, getTwitchToken, filterTwitchM3u8 } from "@lib/twitch";
+import { parseDataFromYtInitial, humanizeData, extractRawData } from "@lib/youtube";
+import { getTwitchLiveResponse, getTwitchVodResponse } from "@lib/twitch";
 import { getKickMasterM3u8 } from "@lib/kick";
 import { estimateHlsStreamSizes } from "@lib/hlsSize";
 
@@ -25,13 +19,20 @@ chrome.runtime.onMessage.addListener((message: FrontEndMessage, sender, sendResp
     return true;
 });
 
+function getTabId(
+    sender: chrome.runtime.MessageSender,
+    message: FrontEndMessage,
+): number | undefined {
+    // If the message is sent from the content script, use sender.tab.id, otherwise use message.tabId (sent from popup)
+    return sender.tab?.id ?? (message.type === "youtubeVideo" ? message.tabId : undefined);
+}
+
 async function handleMessage(
     message: FrontEndMessage,
     sender: chrome.runtime.MessageSender,
     sendResponse: (response: any) => void,
 ): Promise<void> {
-    // If the message is sent from the content script, use sender.tab.id, otherwise use message.tabId (sent from popup)
-    const tabId = sender.tab?.id ?? (message.type === "youtubeVideo" ? message.tabId : undefined);
+    const tabId = getTabId(sender, message);
 
     switch (message.type) {
         case "clearBadge": {
@@ -57,103 +58,29 @@ async function handleMessage(
     }
 }
 
-async function handleTwitch(
-    message: TwitchMessage,
-    sendResponse: (response: TwitchBackgroundResponse) => void,
-) {
-    try {
-        if (message.type === "twitchLive") {
-            const twitchToken = await getTwitchToken(message);
-            const masterM3u8 = await getTwitchMasterM3u8(twitchToken, message);
-            const twitchData = await estimateHlsStreamSizes(masterM3u8);
-
-            return sendResponse({
-                success: true,
-                twitchData: {
-                    type: "live",
-                    data: twitchData,
-                    channelName: message.channelName,
-                },
-            });
-        } else if (message.type === "twitchVod") {
-            const cached = await getFromStorage("twitch", message.vodId);
-            if (cached) {
-                return sendResponse({
-                    success: true,
-                    twitchData: cached.response,
-                    cached: true,
-                    createdAt: cached.createdAt,
-                });
-            }
-
-            const twitchToken = await getTwitchToken(message);
-            if (!twitchToken) {
-                throw new Error("Failed to retrieve Twitch token");
-            }
-            const m3u8Data = await getTwitchMasterM3u8(twitchToken, message);
-            const filteredM3U8Data = filterTwitchM3u8(m3u8Data);
-
-            const response: TwitchData = {
-                type: "vod",
-                data: filteredM3U8Data,
-                vodId: message.vodId,
-                durationSeconds: twitchToken.durationSeconds,
-            };
-            if (filteredM3U8Data.length > 0) {
-                await saveToStorage(message.vodId, response);
-            }
-
-            return sendResponse({
-                success: true,
-                twitchData: response,
-            });
-        }
-    } catch (err) {
-        return sendResponse({
-            success: false,
-            message: err instanceof Error ? err.message : "Unknown error",
-        });
-    }
-}
-
 async function handleYoutube(
     message: YoutubeMessage,
     sendResponse: (response: YoutubeBackgroundResponse) => void,
 ) {
-    const { videoTag, html } = message;
-    if (!videoTag) {
-        return sendResponse({
-            success: false,
-            message: "No video tag provided",
-        });
-    }
-    clearBadge(message.tabId);
-
-    const cached = await getFromStorage("youtube", videoTag);
-    if (cached) {
-        addBadge(message.tabId);
-        return sendResponse({
-            success: true,
-            data: cached.response,
-            cached: true,
-            createdAt: cached.createdAt,
-        });
-    }
-
     try {
-        let rawData;
-        try {
-            if (!html) throw new Error("No HTML");
-            rawData = extractYtInitial(html);
-            if (rawData.videoDetails.videoId !== videoTag) {
-                throw new Error("Video ID mismatch");
-            }
-        } catch {
-            if (html) console.warn("Local HTML extraction failed, falling back to fetchHTMLPage");
-            const pageHtml = await fetchHTMLPage(videoTag);
-            rawData = extractYtInitial(pageHtml);
+        const { videoTag, html } = message;
+        if (!videoTag) {
+            throw new Error("No video tag provided");
+        }
+        clearBadge(message.tabId);
+
+        const cached = await getFromStorage("youtube", videoTag);
+        if (cached) {
+            addBadge(message.tabId);
+            return sendResponse({
+                success: true,
+                data: cached.response,
+                cached: true,
+                createdAt: cached.createdAt,
+            });
         }
 
+        const rawData = await extractRawData(videoTag, html);
         const rawFormats = parseDataFromYtInitial(rawData);
         const humanizedFormats = humanizeData(rawFormats);
 
@@ -168,15 +95,25 @@ async function handleYoutube(
             data: humanizedFormats,
         });
     } catch (err) {
-        console.error(
-            `YouTube data extraction failed: ${err instanceof Error ? err.message : "unknown error"}`,
-            err,
-        );
         clearBadge(message.tabId);
         return sendResponse({
             success: false,
-            data: undefined,
-            cached: false,
+            message: err instanceof Error ? err.message : "Unknown error",
+        });
+    }
+}
+
+async function handleTwitch(
+    message: TwitchMessage,
+    sendResponse: (response: TwitchBackgroundResponse) => void,
+) {
+    try {
+        return message.type === "twitchLive"
+            ? await getTwitchLiveResponse(message, sendResponse)
+            : await getTwitchVodResponse(message, sendResponse);
+    } catch (err) {
+        return sendResponse({
+            success: false,
             message: err instanceof Error ? err.message : "Unknown error",
         });
     }
@@ -198,10 +135,6 @@ async function handleKick(
             kickData,
         });
     } catch (err) {
-        console.error(
-            `Kick data extraction failed: ${err instanceof Error ? err.message : "unknown error"}`,
-            err,
-        );
         return sendResponse({
             success: false,
             message: err instanceof Error ? err.message : "Unknown error",

--- a/tubesize/src/background.ts
+++ b/tubesize/src/background.ts
@@ -15,8 +15,9 @@ import {
     parseDataFromYtInitial,
     humanizeData,
 } from "@lib/youtube";
-import { filterM3U8Data, getM3U8Data, getTwitchToken } from "./lib/twitch";
-import { calculateStreamSizes, getMasterM3U8, mediaPlaylistUrlByHeight } from "./lib/kick";
+import { getTwitchMasterM3u8, getTwitchToken, filterTwitchM3u8 } from "@lib/twitch";
+import { getKickMasterM3u8 } from "@lib/kick";
+import { estimateHlsStreamSizes } from "@lib/hlsSize";
 
 chrome.runtime.onMessage.addListener((message: FrontEndMessage, sender, sendResponse) => {
     void handleMessage(message, sender, sendResponse);
@@ -63,14 +64,14 @@ async function handleTwitch(
     try {
         if (message.type === "twitchLive") {
             const twitchToken = await getTwitchToken(message);
-            const m3u8Data = await getM3U8Data(twitchToken, message);
-            const filteredM3U8Data = filterM3U8Data(m3u8Data);
+            const masterM3u8 = await getTwitchMasterM3u8(twitchToken, message);
+            const twitchData = await estimateHlsStreamSizes(masterM3u8);
 
             return sendResponse({
                 success: true,
                 twitchData: {
                     type: "live",
-                    data: filteredM3U8Data,
+                    data: twitchData,
                     channelName: message.channelName,
                 },
             });
@@ -89,8 +90,8 @@ async function handleTwitch(
             if (!twitchToken) {
                 throw new Error("Failed to retrieve Twitch token");
             }
-            const m3u8Data = await getM3U8Data(twitchToken, message);
-            const filteredM3U8Data = filterM3U8Data(m3u8Data);
+            const m3u8Data = await getTwitchMasterM3u8(twitchToken, message);
+            const filteredM3U8Data = filterTwitchM3u8(m3u8Data);
 
             const response: TwitchData = {
                 type: "vod",
@@ -189,9 +190,8 @@ async function handleKick(
         if (message.type !== "kickLive") {
             throw new Error("Invalid message type for handleKick");
         }
-        const masterM3U8Data = await getMasterM3U8(message.streamId);
-        const parsedMasterM3U8 = mediaPlaylistUrlByHeight(masterM3U8Data);
-        const kickData = await calculateStreamSizes(parsedMasterM3U8, masterM3U8Data);
+        const masterM3U8Data = await getKickMasterM3u8(message.streamId);
+        const kickData = await estimateHlsStreamSizes(masterM3U8Data);
 
         sendResponse({
             success: true,

--- a/tubesize/src/components/header.tsx
+++ b/tubesize/src/components/header.tsx
@@ -18,7 +18,9 @@ function getYoutubeTitle(youtubeData?: YoutubeBackgroundResponse | null): string
 }
 
 function getYoutubeDuration(youtubeData?: YoutubeBackgroundResponse | null): string | undefined {
-    return youtubeData?.data?.durationMinutes;
+    console.log("YouTube duration in seconds:", youtubeData?.data?.durationSeconds);
+    if (!youtubeData?.data?.durationSeconds) return undefined;
+    return humanizeDuration(youtubeData?.data?.durationSeconds * 1000) || undefined;
 }
 
 function getTwitchTitle(twitchData?: TwitchBackgroundResponse | null): string {

--- a/tubesize/src/components/kickFormat.tsx
+++ b/tubesize/src/components/kickFormat.tsx
@@ -1,4 +1,4 @@
-import type { KickBackgroundResponse } from "@/types/types";
+import type { KickBackgroundResponse } from "@app-types/types";
 
 interface Props {
     item: NonNullable<KickBackgroundResponse["kickData"]>[number];

--- a/tubesize/src/components/options/optionItem.tsx
+++ b/tubesize/src/components/options/optionItem.tsx
@@ -1,4 +1,4 @@
-import type { OptionsMap } from "@/types/types";
+import type { OptionsMap } from "@app-types/types";
 import { setToSyncCache } from "@lib/cache";
 
 export default function OptionItem({

--- a/tubesize/src/components/twitchFormat.tsx
+++ b/tubesize/src/components/twitchFormat.tsx
@@ -1,4 +1,4 @@
-import type { TwitchData } from "@/types/types";
+import type { TwitchData } from "@app-types/types";
 
 interface Props {
     item: NonNullable<TwitchData["data"]>[number];

--- a/tubesize/src/components/twitchFormat.tsx
+++ b/tubesize/src/components/twitchFormat.tsx
@@ -1,4 +1,3 @@
-import { bandwidthToSizePerHourMB, bandwidthToSizePerMinuteMB } from "@/lib/utils";
 import type { TwitchData } from "@/types/types";
 
 interface Props {
@@ -12,22 +11,22 @@ function totalSizeDisplay(sizePerMinuteMB: number, durationSeconds?: number): st
     if (!durationSeconds) return "";
     const totalSizeMB = (sizePerMinuteMB / 60) * durationSeconds;
     if (totalSizeMB >= 1000) {
-        return `${(totalSizeMB / 1000).toFixed(1)} GB`;
+        return `${(totalSizeMB / 1000).toFixed(2)} GB`;
     }
-    return `${totalSizeMB.toFixed(1)} MB`;
+    return `${totalSizeMB.toFixed(2)} MB`;
 }
 
 function perHourDisplay(sizePerHourMB: number): string {
     if (sizePerHourMB >= 1000) {
-        return `${(sizePerHourMB / 1000).toFixed(1)} GB/hour`;
+        return `${(sizePerHourMB / 1000).toFixed(2)} GB/hour`;
     }
-    return `${sizePerHourMB.toFixed(1)} MB/hour`;
+    return `${sizePerHourMB.toFixed(2)} MB/hour`;
 }
 
 export default function TwitchFormat({ item, currentQuality, isLive, durationSeconds }: Props) {
     const className = item.resolution === currentQuality ? "format-item current" : "format-item";
-    const sizePerHourMB = bandwidthToSizePerHourMB(item.bandwidth);
-    const sizePerMinuteMB = bandwidthToSizePerMinuteMB(item.bandwidth);
+    const sizePerMinuteMB = (item.sizePerSecondBytes * 60) / 1_000_000;
+    const sizePerHourMB = sizePerMinuteMB * 60;
 
     return (
         <div className={className}>

--- a/tubesize/src/content.ts
+++ b/tubesize/src/content.ts
@@ -16,7 +16,7 @@ import {
     startYoutubeToastTracking,
     stopResolutionTracking,
 } from "@/resolution";
-import { getKickHtml, getStreamId } from "@lib/kick";
+import { getKickHtml, getKickStreamId } from "@lib/kick";
 
 let lastYoutubeTag: string | undefined;
 let lastTwitchTag: string | undefined;
@@ -108,7 +108,8 @@ chrome.runtime.onMessage.addListener(
             void (async () => {
                 const html = document.querySelector("body")!.outerHTML;
                 const streamId =
-                    getStreamId(html) ?? getStreamId(await getKickHtml(globalThis.location.href));
+                    getKickStreamId(html) ??
+                    getKickStreamId(await getKickHtml(globalThis.location.href));
 
                 if (!streamId) {
                     throw new Error("Failed to extract stream ID from the page");

--- a/tubesize/src/lib/constants.ts
+++ b/tubesize/src/lib/constants.ts
@@ -37,7 +37,7 @@ const CONFIG = {
     TOASTER_POLLING_INTERVAL: 5000,
     DEFAULT_TOASTER_ENABLED: true,
     DEFAULT_QUALITY_MENU_ENABLED: true,
-    NUMBER_OF_KICK_SEGMENTS_TO_CHECK: 5,
+    NUMBER_OF_SEGMENTS_TO_CHECK: 5,
     TWITCH_GQL_GRAPHQL_QUERY: `
         query PlaybackAccessToken_Template(
         $login: String!,

--- a/tubesize/src/lib/hlsSize.ts
+++ b/tubesize/src/lib/hlsSize.ts
@@ -23,10 +23,14 @@ async function fetchActualSegments(
                     signal: abortController.signal,
                 });
 
-                if (!res.ok || !res.headers.get("content-range") || res.status !== 206) {
+                if (!res.ok) {
                     throw new Error(`Error fetching segment: ${res.statusText}`);
                 }
-                const fullSize = res.headers.get("content-range")?.split("/")[1];
+
+                const fullSize =
+                    res.status === 206
+                        ? res.headers.get("content-range")?.split("/")[1]
+                        : res.headers.get("content-length");
                 return {
                     duration: segment.duration,
                     fullSize,

--- a/tubesize/src/lib/hlsSize.ts
+++ b/tubesize/src/lib/hlsSize.ts
@@ -9,24 +9,32 @@ async function fetchActualSegments(
         url: string;
     }[],
 ) {
-    return await Promise.allSettled(
+    return Promise.allSettled(
         segments.map(async (segment) => {
-            const res = await fetch(segment.url, {
-                method: "GET",
-                headers: {
-                    Range: "bytes=0-0",
-                },
-            });
-            if (!res.ok || !res.headers.get("content-range") || res.status !== 206) {
-                await res.body?.cancel();
-                throw new Error(`Error fetching segment: ${res.statusText}`);
+            const abortController = new AbortController();
+            const timeout = setTimeout(() => abortController.abort(), 5000);
+            let res: Response | undefined;
+            try {
+                res = await fetch(segment.url, {
+                    method: "GET",
+                    headers: {
+                        Range: "bytes=0-0",
+                    },
+                    signal: abortController.signal,
+                });
+
+                if (!res.ok || !res.headers.get("content-range") || res.status !== 206) {
+                    throw new Error(`Error fetching segment: ${res.statusText}`);
+                }
+                const fullSize = res.headers.get("content-range")?.split("/")[1];
+                return {
+                    duration: segment.duration,
+                    fullSize,
+                };
+            } finally {
+                clearTimeout(timeout);
+                await res?.body?.cancel();
             }
-            const fullSize = res.headers.get("content-range")?.split("/")[1];
-            await res.body?.cancel();
-            return {
-                duration: segment.duration,
-                fullSize,
-            };
         }),
     );
 }

--- a/tubesize/src/lib/hlsSize.ts
+++ b/tubesize/src/lib/hlsSize.ts
@@ -1,0 +1,105 @@
+import type { StreamInfo } from "@app-types/types";
+import CONFIG from "@lib/constants";
+import type { PlaylistItem } from "m3u8-parser";
+import { fetchMediaM3u8, mediaPlaylistUrlByHeight } from "./m3u8";
+
+async function fetchActualSegments(
+    segments: {
+        duration: number;
+        url: string;
+    }[],
+) {
+    return await Promise.allSettled(
+        segments.map(async (segment) => {
+            const res = await fetch(segment.url, {
+                method: "GET",
+                headers: {
+                    Range: "bytes=0-0",
+                },
+            });
+            if (!res.ok || !res.headers.get("content-range") || res.status !== 206) {
+                await res.body?.cancel();
+                throw new Error(`Error fetching segment: ${res.statusText}`);
+            }
+            const fullSize = res.headers.get("content-range")?.split("/")[1];
+            await res.body?.cancel();
+            return {
+                duration: segment.duration,
+                fullSize,
+            };
+        }),
+    );
+}
+
+export async function estimateHlsStreamSizes(
+    masterM3U8Data: PlaylistItem[],
+): Promise<StreamInfo[]> {
+    const mediaUrlByHeight = mediaPlaylistUrlByHeight(masterM3U8Data);
+    const result = await Promise.allSettled(
+        Object.entries(mediaUrlByHeight).map(async ([height, url]) => {
+            const resolution = Number(height);
+
+            try {
+                const manifest = await fetchMediaM3u8(url);
+                const segments = manifest.segments
+                    .map((segment) => ({
+                        duration: segment.duration,
+                        url: segment.uri,
+                    }))
+                    // Limit the number of segments to save fetch time and avoid unnecessary requests.
+                    .slice(0, CONFIG.NUMBER_OF_SEGMENTS_TO_CHECK);
+
+                const results = await fetchActualSegments(segments);
+
+                let totalBytes = 0;
+                let totalDuration = 0;
+                for (const result of results) {
+                    if (result.status === "rejected") continue;
+
+                    const { duration, fullSize } = result.value;
+
+                    if (!fullSize || fullSize === "*" || fullSize === "0") continue;
+                    if (duration > 0) {
+                        totalBytes += Number.parseInt(fullSize, 10);
+                        totalDuration += duration;
+                    }
+                }
+
+                return {
+                    resolution,
+                    // Only calculate size per second if we have a reasonable total duration to avoid inaccurate results from very short segments.
+                    sizePerSecondBytes: totalDuration >= 4 ? totalBytes / totalDuration : 0,
+                };
+            } catch {
+                // Instead of ignoring the rejected promise, we return an object with size set to 0.
+                // This way, we can still fallback to bitrate-based estimation for this resolution in the next step.
+                return {
+                    resolution,
+                    sizePerSecondBytes: 0,
+                };
+            }
+        }),
+    );
+
+    // Fallback to bitrate from master M3U8 if we failed to fetch actual segments.
+    return (
+        result
+            .filter((item) => item.status === "fulfilled")
+            .map((item) => item.value)
+            .map((item) => {
+                if (item.sizePerSecondBytes > 0) {
+                    return item;
+                }
+                const masterItem = masterM3U8Data.find(
+                    (masterItem) => masterItem.attributes.RESOLUTION?.height === item.resolution,
+                );
+                const bitrate = masterItem?.attributes.BANDWIDTH;
+                return {
+                    ...item,
+                    sizePerSecondBytes: bitrate ? bitrate / 8 : 0,
+                };
+            })
+            // eslint-disable-next-line unicorn/no-array-sort
+            .sort((a, b) => b.sizePerSecondBytes - a.sizePerSecondBytes)
+    );
+}

--- a/tubesize/src/lib/kick.ts
+++ b/tubesize/src/lib/kick.ts
@@ -1,8 +1,9 @@
 import { parseM3U8 } from "@lib/m3u8";
 import type { PlaylistItem } from "m3u8-parser";
+import { fetchAndRetry } from "./utils";
 
 export async function getKickHtml(url: string): Promise<string> {
-    const res = await fetch(url, {
+    const res = await fetchAndRetry(url, {
         method: "GET",
         credentials: "include",
     });
@@ -46,7 +47,7 @@ export async function getKickMasterM3u8(streamId: string): Promise<PlaylistItem[
         },
     };
 
-    const playbackRes = await fetch(url, {
+    const playbackRes = await fetchAndRetry(url, {
         method: "POST",
         body: JSON.stringify(payload),
         credentials: "include",
@@ -66,7 +67,7 @@ export async function getKickMasterM3u8(streamId: string): Promise<PlaylistItem[
         throw new Error("Master M3U8 URL not found in playback response");
     }
 
-    const masterM3u8Res = await fetch(m3u8Url);
+    const masterM3u8Res = await fetchAndRetry(m3u8Url);
     if (!masterM3u8Res.ok) {
         throw new Error(`Error fetching master M3U8: ${masterM3u8Res.statusText}`);
     }

--- a/tubesize/src/lib/kick.ts
+++ b/tubesize/src/lib/kick.ts
@@ -1,6 +1,5 @@
-import type { KickStreamInfo } from "@/types/types";
-import { Parser, type Manifest, type PlaylistItem } from "m3u8-parser";
-import CONFIG from "./constants";
+import { parseM3U8 } from "@lib/m3u8";
+import type { PlaylistItem } from "m3u8-parser";
 
 export async function getKickHtml(url: string): Promise<string> {
     const res = await fetch(url, {
@@ -13,14 +12,14 @@ export async function getKickHtml(url: string): Promise<string> {
     return await res.text();
 }
 
-export function getStreamId(html: string): string | undefined {
+export function getKickStreamId(html: string): string | undefined {
     const match =
         String(html).match(/vod_id\\":\\"([^\\]+)/) || String(html).match(/vod_id":"([^"]+)"}/);
     if (!match?.[1]) return;
     return match[1];
 }
 
-export async function getMasterM3U8(streamId: string) {
+export async function getKickMasterM3u8(streamId: string): Promise<PlaylistItem[]> {
     const url = `https://web.kick.com/api/v1/stream/${streamId}/playback`;
     const payload = {
         video_player: {
@@ -79,120 +78,4 @@ export async function getMasterM3U8(streamId: string) {
     }
 
     return playlists;
-}
-
-function parseM3U8(m3u8Data: string): Manifest {
-    const parser = new Parser();
-    parser.push(m3u8Data);
-    parser.end();
-    return parser.manifest;
-}
-export function mediaPlaylistUrlByHeight(m3u8Data: PlaylistItem[]): Record<number, string> {
-    const mediaPlaylistUrlByHeight: Record<number, string> = {};
-    for (const item of m3u8Data) {
-        const height = item.attributes.RESOLUTION?.height;
-        const url = item.uri;
-        if (!height || !url) continue;
-        mediaPlaylistUrlByHeight[height] = url;
-    }
-
-    return mediaPlaylistUrlByHeight;
-}
-
-export async function calculateStreamSizes(
-    mediaPlaylistUrlByHeight: Record<number, string>,
-    masterM3U8Data: PlaylistItem[],
-): Promise<KickStreamInfo[]> {
-    const result = await Promise.allSettled(
-        Object.keys(mediaPlaylistUrlByHeight).map(async (height) => {
-            const url = mediaPlaylistUrlByHeight[Number(height)];
-            const resolution = Number(height);
-
-            try {
-                const segmentUrls = await getSegmentUrls(url);
-                // Limit the number of segments to save fetch time and avoid unnecessary requests.
-                const segments = segmentUrls.slice(0, CONFIG.NUMBER_OF_KICK_SEGMENTS_TO_CHECK);
-
-                let totalBytes = 0;
-                let totalDuration = 0;
-                const results = await Promise.allSettled(
-                    segments.map(async (segment) => {
-                        const res = await fetch(segment.url, {
-                            method: "GET",
-                            headers: {
-                                Range: "bytes=0-0",
-                            },
-                        });
-                        if (!res.ok || !res.headers.get("content-range") || res.status !== 206) {
-                            throw new Error(`Error fetching segment: ${res.statusText}`);
-                        }
-                        return { segment, res };
-                    }),
-                );
-
-                for (const result of results) {
-                    if (result.status === "rejected") continue;
-
-                    const { segment, res } = result.value;
-                    const fullSize = res.headers.get("content-range")?.split("/")[1];
-                    await res.body?.cancel();
-
-                    if (!fullSize || fullSize === "*" || fullSize === "0") continue;
-                    if (segment.duration > 0) {
-                        totalBytes += Number.parseInt(fullSize, 10);
-                        totalDuration += segment.duration;
-                    }
-                }
-
-                return {
-                    resolution,
-                    // Only calculate size per second if we have a reasonable total duration to avoid inaccurate results from very short segments.
-                    sizePerSecondBytes: totalDuration >= 4 ? totalBytes / totalDuration : 0,
-                };
-            } catch {
-                // Instead of ignoring the rejected promise, we return an object with size set to 0.
-                // This way, we can still fallback to bitrate-based estimation for this resolution in the next step.
-                return {
-                    resolution,
-                    sizePerSecondBytes: 0,
-                };
-            }
-        }),
-    );
-
-    return (
-        result
-            .filter((item) => item.status === "fulfilled")
-            .map((item) => item.value)
-            .map((item) => {
-                if (item.sizePerSecondBytes > 0) {
-                    return item;
-                }
-                const masterItem = masterM3U8Data.find(
-                    (masterItem) => masterItem.attributes.RESOLUTION?.height === item.resolution,
-                );
-                const bitrate = masterItem?.attributes.BANDWIDTH;
-                return {
-                    ...item,
-                    sizePerSecondBytes: bitrate ? bitrate / 8 : 0,
-                };
-            })
-            // eslint-disable-next-line unicorn/no-array-sort
-            .sort((a, b) => b.sizePerSecondBytes - a.sizePerSecondBytes)
-    );
-}
-
-async function getSegmentUrls(m3u8Url: string): Promise<{ url: string; duration: number }[]> {
-    const res = await fetch(m3u8Url);
-    if (!res.ok) {
-        throw new Error(`Error fetching media playlist M3U8: ${res.statusText}`);
-    }
-    const m3u8Data = await res.text();
-
-    const manifest = parseM3U8(m3u8Data);
-    const segments = manifest.segments;
-    return segments.map((segment) => ({
-        duration: segment.duration,
-        url: segment.uri,
-    }));
 }

--- a/tubesize/src/lib/m3u8.ts
+++ b/tubesize/src/lib/m3u8.ts
@@ -1,5 +1,6 @@
 import { Parser } from "m3u8-parser";
 import type { Manifest, PlaylistItem } from "m3u8-parser";
+import { fetchAndRetry } from "./utils";
 
 export function parseM3U8(m3u8Data: string): Manifest {
     const parser = new Parser();
@@ -21,7 +22,7 @@ export function mediaPlaylistUrlByHeight(m3u8Data: PlaylistItem[]): Record<numbe
 }
 
 export async function fetchMediaM3u8(m3u8MediaUrl: string) {
-    const res = await fetch(m3u8MediaUrl);
+    const res = await fetchAndRetry(m3u8MediaUrl);
     if (!res.ok) {
         console.log("Failed to fetch media playlist M3U8:", res.statusText);
         throw new Error(`Error fetching media playlist M3U8: ${res.statusText}`);

--- a/tubesize/src/lib/m3u8.ts
+++ b/tubesize/src/lib/m3u8.ts
@@ -1,0 +1,32 @@
+import { Parser } from "m3u8-parser";
+import type { Manifest, PlaylistItem } from "m3u8-parser";
+
+export function parseM3U8(m3u8Data: string): Manifest {
+    const parser = new Parser();
+    parser.push(m3u8Data);
+    parser.end();
+    return parser.manifest;
+}
+
+export function mediaPlaylistUrlByHeight(m3u8Data: PlaylistItem[]): Record<number, string> {
+    const mediaPlaylistUrlByHeight: Record<number, string> = {};
+    for (const item of m3u8Data) {
+        const height = item.attributes.RESOLUTION?.height;
+        const url = item.uri;
+        if (!height || !url) continue;
+        mediaPlaylistUrlByHeight[height] = url;
+    }
+
+    return mediaPlaylistUrlByHeight;
+}
+
+export async function fetchMediaM3u8(m3u8MediaUrl: string) {
+    const res = await fetch(m3u8MediaUrl);
+    if (!res.ok) {
+        console.log("Failed to fetch media playlist M3U8:", res.statusText);
+        throw new Error(`Error fetching media playlist M3U8: ${res.statusText}`);
+    }
+    const m3u8Data = await res.text();
+
+    return parseM3U8(m3u8Data);
+}

--- a/tubesize/src/lib/twitch.ts
+++ b/tubesize/src/lib/twitch.ts
@@ -95,6 +95,7 @@ export async function getTwitchMasterM3u8(
 
     url.searchParams.set("token", tokenData.value);
     url.searchParams.set("sig", tokenData.signature);
+    url.searchParams.set("allow_source", "true");
 
     const res = await fetch(url);
     if (!res.ok) {

--- a/tubesize/src/lib/twitch.ts
+++ b/tubesize/src/lib/twitch.ts
@@ -1,7 +1,17 @@
-import type { TwitchData, TwitchGqlResponse, TwitchMessage, TwitchTokenData } from "@/types/types";
+import type {
+    TwitchBackgroundResponse,
+    TwitchData,
+    TwitchGqlResponse,
+    TwitchLiveMessage,
+    TwitchMessage,
+    TwitchTokenData,
+    TwitchVodMessage,
+} from "@app-types/types";
 import type { PlaylistItem } from "m3u8-parser";
 import CONFIG from "@lib/constants";
+import { estimateHlsStreamSizes } from "./hlsSize";
 import { parseM3U8 } from "@lib/m3u8";
+import { getFromStorage, saveToStorage } from "./cache";
 
 export async function getTwitchClientId(message: TwitchMessage): Promise<string> {
     const url =
@@ -111,4 +121,59 @@ export function filterTwitchM3u8(m3u8Data: PlaylistItem[]): TwitchData["data"] {
         });
 
     return result || [];
+}
+
+export async function getTwitchLiveResponse(
+    message: TwitchLiveMessage,
+    sendResponse: (response: TwitchBackgroundResponse) => void,
+) {
+    const twitchToken = await getTwitchToken(message);
+    const masterM3u8 = await getTwitchMasterM3u8(twitchToken, message);
+    const twitchData = await estimateHlsStreamSizes(masterM3u8);
+
+    return sendResponse({
+        success: true,
+        twitchData: {
+            type: "live",
+            data: twitchData,
+            channelName: message.channelName,
+        },
+    });
+}
+
+export async function getTwitchVodResponse(
+    message: TwitchVodMessage,
+    sendResponse: (response: TwitchBackgroundResponse) => void,
+) {
+    const cached = await getFromStorage("twitch", message.vodId);
+    if (cached) {
+        return sendResponse({
+            success: true,
+            twitchData: cached.response,
+            cached: true,
+            createdAt: cached.createdAt,
+        });
+    }
+
+    const twitchToken = await getTwitchToken(message);
+    if (!twitchToken) {
+        throw new Error("Failed to retrieve Twitch token");
+    }
+    const m3u8Data = await getTwitchMasterM3u8(twitchToken, message);
+    const filteredM3U8Data = filterTwitchM3u8(m3u8Data);
+
+    const response: TwitchData = {
+        type: "vod",
+        data: filteredM3U8Data,
+        vodId: message.vodId,
+        durationSeconds: twitchToken.durationSeconds,
+    };
+    if (filteredM3U8Data.length > 0) {
+        await saveToStorage(message.vodId, response);
+    }
+
+    return sendResponse({
+        success: true,
+        twitchData: response,
+    });
 }

--- a/tubesize/src/lib/twitch.ts
+++ b/tubesize/src/lib/twitch.ts
@@ -12,13 +12,14 @@ import CONFIG from "@lib/constants";
 import { estimateHlsStreamSizes } from "./hlsSize";
 import { parseM3U8 } from "@lib/m3u8";
 import { getFromStorage, saveToStorage } from "./cache";
+import { fetchAndRetry } from "./utils";
 
 export async function getTwitchClientId(message: TwitchMessage): Promise<string> {
     const url =
         message.type === "twitchVod"
             ? `https://www.twitch.tv/videos/${message.vodId}`
             : `https://www.twitch.tv/${message.channelName}`;
-    const res = await fetch(url);
+    const res = await fetchAndRetry(url);
     if (!res.ok) {
         throw new Error("Failed to fetch Twitch page");
     }
@@ -51,7 +52,7 @@ export async function getTwitchToken(message: TwitchMessage): Promise<TwitchToke
             },
         };
 
-        const res = await fetch("https://gql.twitch.tv/gql", {
+        const res = await fetchAndRetry("https://gql.twitch.tv/gql", {
             method: "POST",
             headers,
             body: JSON.stringify(body),
@@ -97,7 +98,7 @@ export async function getTwitchMasterM3u8(
     url.searchParams.set("sig", tokenData.signature);
     url.searchParams.set("allow_source", "true");
 
-    const res = await fetch(url);
+    const res = await fetchAndRetry(url);
     if (!res.ok) {
         throw new Error("Failed to fetch Twitch m3u8 data");
     }

--- a/tubesize/src/lib/twitch.ts
+++ b/tubesize/src/lib/twitch.ts
@@ -1,8 +1,9 @@
 import type { TwitchData, TwitchGqlResponse, TwitchMessage, TwitchTokenData } from "@/types/types";
-import { Parser } from "m3u8-parser";
+import type { PlaylistItem } from "m3u8-parser";
 import CONFIG from "@lib/constants";
+import { parseM3U8 } from "@lib/m3u8";
 
-export async function getClientId(message: TwitchMessage): Promise<string> {
+export async function getTwitchClientId(message: TwitchMessage): Promise<string> {
     const url =
         message.type === "twitchVod"
             ? `https://www.twitch.tv/videos/${message.vodId}`
@@ -23,7 +24,7 @@ export async function getClientId(message: TwitchMessage): Promise<string> {
 
 export async function getTwitchToken(message: TwitchMessage): Promise<TwitchTokenData> {
     try {
-        const clientId = await getClientId(message);
+        const clientId = await getTwitchClientId(message);
         const headers = {
             "Client-Id": clientId,
             "Content-Type": "application/json",
@@ -73,10 +74,10 @@ export async function getTwitchToken(message: TwitchMessage): Promise<TwitchToke
     }
 }
 
-export async function getM3U8Data(
+export async function getTwitchMasterM3u8(
     tokenData: TwitchTokenData,
     message: TwitchMessage,
-): Promise<string> {
+): Promise<PlaylistItem[]> {
     const url =
         message.type === "twitchLive"
             ? new URL(`https://usher.ttvnw.net/api/v2/channel/hls/${message.channelName}.m3u8`)
@@ -89,27 +90,23 @@ export async function getM3U8Data(
     if (!res.ok) {
         throw new Error("Failed to fetch Twitch m3u8 data");
     }
-    return await res.text();
+    const m3u8Data = await res.text();
+    const parsed = parseM3U8(m3u8Data);
+    const playlists = parsed.playlists;
+    if (!playlists || playlists.length === 0) {
+        throw new Error("No playlists found in Twitch m3u8 data");
+    }
+
+    return playlists;
 }
 
-export function filterM3U8Data(m3u8Data: string): TwitchData["data"] {
-    const parser = new Parser();
-    parser.push(m3u8Data);
-    parser.end();
-
-    const parsed = parser.manifest.playlists;
-    const result = parsed
-        ?.filter(
-            (item) =>
-                item.attributes.RESOLUTION?.height &&
-                item.attributes.BANDWIDTH &&
-                item.attributes.CODECS,
-        )
+export function filterTwitchM3u8(m3u8Data: PlaylistItem[]): TwitchData["data"] {
+    const result = m3u8Data
+        ?.filter((item) => item.attributes.RESOLUTION?.height && item.attributes.BANDWIDTH)
         .map((item) => {
             return {
-                bandwidth: item.attributes.BANDWIDTH!,
+                sizePerSecondBytes: item.attributes.BANDWIDTH! / 8,
                 resolution: item.attributes.RESOLUTION!.height,
-                codec: item.attributes.CODECS!,
             };
         });
 

--- a/tubesize/src/lib/utils.ts
+++ b/tubesize/src/lib/utils.ts
@@ -133,7 +133,7 @@ export function extractVideoTag(ytUrl: string): string | undefined {
 }
 
 export async function fetchAndRetry(
-    url: string,
+    url: string | URL,
     options: RequestInit = {},
     maxRetries = CONFIG.DEFAULT_MAX_RETRIES,
 ): Promise<Response> {

--- a/tubesize/src/lib/utils.ts
+++ b/tubesize/src/lib/utils.ts
@@ -192,10 +192,3 @@ export function humanizeDuration(ms: number) {
     }
     return baseHumanizeDuration(ms);
 }
-
-export function bandwidthToSizePerMinuteMB(bandwidth: number): number {
-    return (bandwidth / 8 / 1_000_000) * 60;
-}
-export function bandwidthToSizePerHourMB(bandwidth: number): number {
-    return (bandwidth / 8 / 1_000_000) * 60 * 60;
-}

--- a/tubesize/src/lib/youtube.ts
+++ b/tubesize/src/lib/youtube.ts
@@ -94,7 +94,7 @@ export function mergeAudioWithVideo(videoFormats: RawFormat["formats"], audioSiz
     });
 }
 
-export async function fetchHTMLPage(videoTag: string) {
+async function fetchHTMLPage(videoTag: string) {
     const res = await fetchAndRetry(`https://www.youtube.com/watch?v=${videoTag}`, {
         method: "GET",
         signal: AbortSignal.timeout(CONFIG.FETCH_HTML_TIMEOUT),

--- a/tubesize/src/lib/youtube.ts
+++ b/tubesize/src/lib/youtube.ts
@@ -17,6 +17,24 @@ export function sizePerMinute(
     return Number((sizeInMB / durationInMinutes).toFixed(2));
 }
 
+export async function extractRawData(videoTag: string, html: string | undefined): Promise<RawData> {
+    let rawData: RawData | undefined;
+    try {
+        if (!html) throw new Error("No HTML");
+        rawData = extractYtInitial(html);
+        if (rawData.videoDetails.videoId !== videoTag) {
+            throw new Error("Video ID mismatch");
+        }
+    } catch {
+        const pageHtml = await fetchHTMLPage(videoTag);
+        rawData = extractYtInitial(pageHtml);
+    }
+    if (!rawData) {
+        throw new Error("Failed to extract raw data");
+    }
+    return rawData;
+}
+
 export function humanizeData(formats: RawFormat): HumanizedFormat {
     const audioSize = getAverageAudioSize(formats.audioFormats);
     const mergedFormats = mergeAudioWithVideo(formats.formats, audioSize);

--- a/tubesize/src/lib/youtube.ts
+++ b/tubesize/src/lib/youtube.ts
@@ -1,6 +1,6 @@
 import { filesize } from "filesize";
 import type { HumanizedFormat, RawData, RawFormat } from "@app-types/types";
-import { fetchAndRetry, humanizeDuration } from "@lib/utils";
+import { fetchAndRetry } from "@lib/utils";
 import CONFIG from "@lib/constants";
 
 export function sizePerMinute(
@@ -47,7 +47,7 @@ export function humanizeData(formats: RawFormat): HumanizedFormat {
     return {
         id: formats.id,
         title: formats.title,
-        durationMinutes: humanizeDuration(formats.durationSeconds * 1000),
+        durationSeconds: formats.durationSeconds,
         videoFormats: humanizedVideoFormats,
         isLive: formats.isLive,
     };

--- a/tubesize/src/pages/popup.tsx
+++ b/tubesize/src/pages/popup.tsx
@@ -216,24 +216,21 @@ export default function Popup() {
                         // eslint-disable-next-line unicorn/no-array-reverse
                         .reverse()}
                 {twitchData?.twitchData?.data &&
-                    twitchData?.twitchData?.data
-                        // eslint-disable-next-line unicorn/no-array-sort
-                        .sort((a, b) => b.bandwidth - a.bandwidth)
-                        .map((item) => {
-                            return (
-                                <TwitchFormat
-                                    key={item.resolution}
-                                    item={item}
-                                    currentQuality={currentQuality}
-                                    isLive={isLive}
-                                    durationSeconds={
-                                        twitchData.twitchData?.type === "vod"
-                                            ? twitchData.twitchData.durationSeconds
-                                            : undefined
-                                    }
-                                />
-                            );
-                        })}
+                    twitchData?.twitchData?.data.map((item) => {
+                        return (
+                            <TwitchFormat
+                                key={item.resolution}
+                                item={item}
+                                currentQuality={currentQuality}
+                                isLive={isLive}
+                                durationSeconds={
+                                    twitchData.twitchData?.type === "vod"
+                                        ? twitchData.twitchData.durationSeconds
+                                        : undefined
+                                }
+                            />
+                        );
+                    })}
                 {kickData?.kickData &&
                     kickData.kickData.map((item) => {
                         return (

--- a/tubesize/src/pages/toaster.tsx
+++ b/tubesize/src/pages/toaster.tsx
@@ -1,7 +1,6 @@
 import { createRoot } from "react-dom/client";
 import type { TwitchBackgroundResponse, YoutubeBackgroundResponse } from "@app-types/types";
 import Toast from "@components/toast";
-import { bandwidthToSizePerMinuteMB } from "@/lib/utils";
 
 const HOST_ID = "TubeSize-Toast-Host";
 
@@ -53,7 +52,7 @@ export function showTwitchToast(
 
     const format = videoFormats.find((format) => format.resolution === currentQuality);
     if (!format) return;
-    const sizePerMinuteMB = bandwidthToSizePerMinuteMB(format.bandwidth);
+    const sizePerMinuteMB = (format.sizePerSecondBytes / 1000 / 1000) * 60;
     if (sizePerMinuteMB > toasterThresholdMbpm) {
         const sizeMB =
             !isLive && durationSeconds

--- a/tubesize/src/tests/twitch.test.ts
+++ b/tubesize/src/tests/twitch.test.ts
@@ -54,7 +54,7 @@ describe("getTwitchToken", () => {
             value: '{"foo":"bar"}',
             signature: "live-signature",
         });
-        expect(fetchMock).toHaveBeenNthCalledWith(1, "https://www.twitch.tv/hivise");
+        expect(fetchMock).toHaveBeenNthCalledWith(1, "https://www.twitch.tv/hivise", {});
         expect(fetchMock).toHaveBeenCalledTimes(2);
         expect(fetchMock.mock.calls[1]?.[0]).toBe("https://gql.twitch.tv/gql");
 
@@ -108,7 +108,7 @@ describe("getTwitchToken", () => {
             value: '{"vod":true}',
             signature: "vod-signature",
         });
-        expect(fetchMock).toHaveBeenNthCalledWith(1, "https://www.twitch.tv/videos/2748008198");
+        expect(fetchMock).toHaveBeenNthCalledWith(1, "https://www.twitch.tv/videos/2748008198", {});
 
         const request = fetchMock.mock.calls[1]?.[1] as RequestInit | undefined;
         if (!request) {
@@ -154,7 +154,7 @@ describe("getTwitchMasterM3u8", () => {
         const requestUrl = fetchMock.mock.calls[0]?.[0] as URL | undefined;
 
         expect(requestUrl?.toString()).toBe(
-            "https://usher.ttvnw.net/api/v2/channel/hls/hivise.m3u8?token=%7B%22token%22%3A%22live%22%7D&sig=live-signature",
+            "https://usher.ttvnw.net/api/v2/channel/hls/hivise.m3u8?token=%7B%22token%22%3A%22live%22%7D&sig=live-signature&allow_source=true",
         );
     });
 
@@ -183,7 +183,7 @@ describe("getTwitchMasterM3u8", () => {
         const requestUrl = fetchMock.mock.calls[0]?.[0] as URL | undefined;
 
         expect(requestUrl?.toString()).toBe(
-            "https://usher.ttvnw.net/vod/v2/2748008198.m3u8?token=%7B%22token%22%3A%22vod%22%7D&sig=vod-signature",
+            "https://usher.ttvnw.net/vod/v2/2748008198.m3u8?token=%7B%22token%22%3A%22vod%22%7D&sig=vod-signature&allow_source=true",
         );
     });
 });

--- a/tubesize/src/tests/twitch.test.ts
+++ b/tubesize/src/tests/twitch.test.ts
@@ -1,5 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { filterM3U8Data, getClientId, getM3U8Data, getTwitchToken } from "@lib/twitch";
+import {
+    filterTwitchM3u8,
+    getTwitchClientId,
+    getTwitchMasterM3u8,
+    getTwitchToken,
+} from "@lib/twitch";
+import { parseM3U8 } from "@lib/m3u8";
 import path from "node:path";
 import fs from "node:fs";
 
@@ -7,7 +13,7 @@ afterEach(() => {
     jest.resetAllMocks();
 });
 
-describe("getClientId", () => {
+describe("getTwitchClientId", () => {
     test("should extract client ID from Twitch page", async () => {
         const channelName = "hivise";
         const htmlPath = path.join(process.cwd(), "src", "tests", "assets", "twitch.html");
@@ -15,7 +21,7 @@ describe("getClientId", () => {
             ok: true,
             text: () => fs.readFileSync(htmlPath, "utf8"),
         });
-        const clientId = await getClientId({ channelName, type: "twitchLive" });
+        const clientId = await getTwitchClientId({ channelName, type: "twitchLive" });
         expect(clientId).toBe("kimne78kx3ncx6brgo4mv6wki5et0ko");
     });
 });
@@ -123,21 +129,27 @@ describe("getTwitchToken", () => {
     });
 });
 
-describe("getM3U8Data", () => {
+describe("getTwitchMasterM3u8", () => {
     test("should request live m3u8 data with token and signature", async () => {
         const fetchMock = jest.fn().mockResolvedValue({
             ok: true,
-            text: () => "#EXTM3U\n",
+            text: () => `#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=2602418,RESOLUTION=1280x720
+720p.m3u8
+`,
         });
 
         globalThis.fetch = fetchMock;
 
-        const data = await getM3U8Data(
+        const data = await getTwitchMasterM3u8(
             { value: '{"token":"live"}', signature: "live-signature" },
             { type: "twitchLive", channelName: "hivise" },
         );
 
-        expect(data).toBe("#EXTM3U\n");
+        expect(data).toHaveLength(1);
+        expect(data[0]?.uri).toBe("720p.m3u8");
+        expect(data[0]?.attributes.BANDWIDTH).toBe(2_602_418);
+        expect(data[0]?.attributes.RESOLUTION?.height).toBe(720);
 
         const requestUrl = fetchMock.mock.calls[0]?.[0] as URL | undefined;
 
@@ -149,17 +161,24 @@ describe("getM3U8Data", () => {
     test("should request vod m3u8 data with token and signature", async () => {
         const fetchMock = jest.fn().mockResolvedValue({
             ok: true,
-            text: () => "#EXTM3U\n#EXT-X-ENDLIST\n",
+            text: () => `#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=1627418,RESOLUTION=852x480
+480p.m3u8
+#EXT-X-ENDLIST
+`,
         });
 
         globalThis.fetch = fetchMock;
 
-        const data = await getM3U8Data(
+        const data = await getTwitchMasterM3u8(
             { value: '{"token":"vod"}', signature: "vod-signature" },
             { type: "twitchVod", vodId: "2748008198" },
         );
 
-        expect(data).toBe("#EXTM3U\n#EXT-X-ENDLIST\n");
+        expect(data).toHaveLength(1);
+        expect(data[0]?.uri).toBe("480p.m3u8");
+        expect(data[0]?.attributes.BANDWIDTH).toBe(1_627_418);
+        expect(data[0]?.attributes.RESOLUTION?.height).toBe(480);
 
         const requestUrl = fetchMock.mock.calls[0]?.[0] as URL | undefined;
 
@@ -169,8 +188,8 @@ describe("getM3U8Data", () => {
     });
 });
 
-describe("filterM3U8Data", () => {
-    test("should keep only m3u8 variants with resolution, bandwidth and codec", () => {
+describe("filterTwitchM3u8", () => {
+    test("should keep only m3u8 variants with resolution and bandwidth", () => {
         const m3u8Data = `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-STREAM-INF:BANDWIDTH=2602418,RESOLUTION=1280x720,CODECS="avc1.64001F,mp4a.40.2"
@@ -181,16 +200,14 @@ describe("filterM3U8Data", () => {
 360p.m3u8
 `;
 
-        expect(filterM3U8Data(m3u8Data)).toEqual([
+        expect(filterTwitchM3u8(parseM3U8(m3u8Data).playlists ?? [])).toEqual([
             {
-                bandwidth: 2_602_418,
+                sizePerSecondBytes: 325_302.25,
                 resolution: 720,
-                codec: "avc1.64001F,mp4a.40.2",
             },
             {
-                bandwidth: 1_627_418,
+                sizePerSecondBytes: 203_427.25,
                 resolution: 480,
-                codec: "avc1.4D401F,mp4a.40.2",
             },
         ]);
     });
@@ -202,6 +219,6 @@ describe("filterM3U8Data", () => {
 audio-only.m3u8
 `;
 
-        expect(filterM3U8Data(m3u8Data)).toEqual([]);
+        expect(filterTwitchM3u8(parseM3U8(m3u8Data).playlists ?? [])).toEqual([]);
     });
 });

--- a/tubesize/src/tests/utils.test.ts
+++ b/tubesize/src/tests/utils.test.ts
@@ -3,8 +3,6 @@ import {
     isShortsVideo,
     extractVideoTag,
     fetchAndRetry,
-    bandwidthToSizePerHourMB,
-    bandwidthToSizePerMinuteMB,
     isTwitchPage,
     isTwitchVod,
     extractTwitchVodId,
@@ -162,20 +160,6 @@ describe("extractVideoTag", () => {
 
     test("should return undefined for youtube short video with invalid itag", () => {
         expect(extractVideoTag("https://www.youtube.com/shorts/muzkbNA0")).toBeNil();
-    });
-});
-
-describe("bandwidthToSizePerMinuteMB", () => {
-    test("should convert bits per second to megabytes per minute", () => {
-        // 8,000,000 bits/s = 1 MB/s = 60 MB/min
-        expect(bandwidthToSizePerMinuteMB(8_000_000)).toBeCloseTo(60, 5);
-    });
-});
-
-describe("bandwidthToSizePerHourMB", () => {
-    test("should convert bits per second to megabytes per hour", () => {
-        // 8,000,000 bits/s = 1 MB/s = 3600 MB/hour
-        expect(bandwidthToSizePerHourMB(8_000_000)).toBeCloseTo(3600, 5);
     });
 });
 

--- a/tubesize/src/tests/youtube.test.ts
+++ b/tubesize/src/tests/youtube.test.ts
@@ -1,4 +1,4 @@
-import type { HumanizedFormat, RawData, RawFormat } from "@/types/types";
+import type { HumanizedFormat, RawData, RawFormat } from "@app-types/types";
 import fs from "node:fs";
 import path from "node:path";
 import {

--- a/tubesize/src/types/types.ts
+++ b/tubesize/src/types/types.ts
@@ -93,15 +93,14 @@ export type TwitchTokenData = {
     durationSeconds?: number;
 };
 
-type TwitchStreamInfo = {
-    bandwidth: number;
+export type StreamInfo = {
+    sizePerSecondBytes: number;
     resolution: number;
-    codec: string;
 };
 
 export type TwitchData =
-    | { type: "live"; data: TwitchStreamInfo[]; channelName: string }
-    | { type: "vod"; data: TwitchStreamInfo[]; vodId: string; durationSeconds: number | undefined };
+    | { type: "live"; data: StreamInfo[]; channelName: string }
+    | { type: "vod"; data: StreamInfo[]; vodId: string; durationSeconds: number | undefined };
 
 export type TwitchBackgroundResponse = {
     success: boolean;
@@ -111,14 +110,9 @@ export type TwitchBackgroundResponse = {
     createdAt?: string;
 };
 
-export type KickStreamInfo = {
-    resolution: number;
-    sizePerSecondBytes: number;
-};
-
 export type KickBackgroundResponse = {
     success: boolean;
-    kickData?: KickStreamInfo[];
+    kickData?: StreamInfo[];
     message?: string;
     channelName?: string;
 };

--- a/tubesize/src/types/types.ts
+++ b/tubesize/src/types/types.ts
@@ -37,7 +37,7 @@ export type HumanizedFormat = {
     id: string;
     title: string;
     isLive: boolean;
-    durationMinutes: string;
+    durationSeconds: number;
     videoFormats: {
         formatId: number;
         height: number;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR improves the accuracy of live stream size estimation (Twitch & Kick) by refactoring HLS handling to measure actual segment bytes and durations, and applies a number of supporting API, type, and UI changes.

## Key changes

- HLS size estimation
  - Add new estimateHlsStreamSizes(masterM3U8Data) that samples media playlists, issues range requests on a limited number of segments, computes sizePerSecondBytes from sampled bytes/duration, and falls back to manifest BANDWIDTH/8 when sampling fails.
  - Results returned as StreamInfo[] sorted by descending sizePerSecondBytes.

- Twitch & Kick integration
  - Twitch: replace raw m3u8 string handling with getTwitchMasterM3u8 (returns parsed PlaylistItem[]), use estimateHlsStreamSizes for live streams, and introduce getTwitchLiveResponse / getTwitchVodResponse helpers.
  - Kick: rename and simplify to getKickStreamId and getKickMasterM3u8 (now returns parsed playlists). Removed legacy Kick segment-size calculation logic; Kick now relies on the shared HLS estimator.
  - Network calls now use fetchAndRetry consistently.

- Types & utilities
  - Introduce unified StreamInfo type { sizePerSecondBytes, resolution } and remove TwitchStreamInfo/KickStreamInfo, plus removed codec/bandwidth fields.
  - Remove bandwidthToSizePerMinuteMB / bandwidthToSizePerHourMB helpers; components now compute sizes directly from sizePerSecondBytes.
  - fetchAndRetry now accepts string | URL.

- M3U8 tooling
  - New m3u8 module: parseM3U8 (wraps m3u8-parser Manifest), mediaPlaylistUrlByHeight, and fetchMediaM3U8 (fetch + parse + error handling).

- UI & display
  - TwitchFormat and toaster now derive sizes from sizePerSecondBytes and show 2 decimal places (previously 1).
  - Popup no longer sorts Twitch entries by bandwidth; it preserves manifest order.

- YouTube handling
  - Add extractRawData(videoTag, html) to robustly extract ytInitial from optional HTML and fallback to fetching the page when needed.
  - fetchHTMLPage made non-exported.

- Constants, names, and manifest
  - Rename NUMBER_OF_KICK_SEGMENTS_TO_CHECK → NUMBER_OF_SEGMENTS_TO_CHECK.
  - manifest host_permissions broadened to include additional Twitch/usher/playlist/cloudfront patterns to support segment/playlist sampling.

- Tests & cleanup
  - Tests updated to assert parsed PlaylistItem shapes and the new StreamInfo output shape.
  - Removed unit tests for the removed bandwidth conversion helpers.
  - Some console.error logging reduced in background flow; response error behavior preserved.

## Notes for reviewers

- Surface-area changes: medium-to-high — core HLS logic added (+ estimateHlsStreamSizes, m3u8 helpers) and many callers updated (background, twitch, kick, UI, types).
- Focus review on: correctness of range request handling and fallback logic in hlsSize.ts, proper parsing/validation in m3u8.ts and youtube.extractRawData, and any missing host_permissions needed for real-world sampling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->