### PR TITLE
Badge that shows today's usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ devTest/
 coverage/
 code_review/
 .release/
+*.tsbuildinfo

--- a/scripts/release.cjs
+++ b/scripts/release.cjs
@@ -25,7 +25,7 @@ function checkGitClean() {
 }
 
 function gitCommit() {
-    execFileSync("git", ["add", "package.json", "manifest.json"], { stdio: "inherit" });
+    execFileSync("git", ["add", "package.json"], { stdio: "inherit" });
     execFileSync("git", ["commit", "-m", `Release ${fullVersion}`], { stdio: "inherit" });
 }
 
@@ -77,7 +77,6 @@ function main() {
         process.exit(1);
     }
     checkGitClean();
-    updateJsonVersion(path.join(__dirname, "..", "manifest.json"));
     updateJsonVersion(path.join(__dirname, "..", "package.json"));
     gitCommit();
     pack();

--- a/src/background.ts
+++ b/src/background.ts
@@ -20,8 +20,8 @@ import {
 } from "@lib/youtube";
 import { getTwitchLiveResponse, getTwitchVodResponse } from "@lib/twitch";
 import { getKickLiveResponse, getKickVodResponse } from "@lib/kick";
-import { isYoutubePage } from "./lib/utils";
-import { getTotalUsageForDate, getUsageByDay, utcDateKey } from "./lib/analyticsUtils";
+import { isYoutubePage } from "@lib/utils";
+import { getTotalUsageForDate, getUsageByDay, utcDateKey } from "@lib/analyticsUtils";
 
 chrome.runtime.onMessage.addListener((message: FrontEndMessage, sender, sendResponse) => {
     void handleMessage(message, sender, sendResponse);
@@ -45,7 +45,7 @@ async function handleMessage(
 
     switch (message.type) {
         case "removeBadge": {
-            return handleRemoveBadge(message, sendResponse);
+            return handleRemoveBadge(tabId, sendResponse);
         }
         case "setBadge": {
             return handleSetBadge(message, tabId, sendResponse);
@@ -176,10 +176,10 @@ chrome.runtime.onInstalled.addListener((details) => {
 });
 
 function handleRemoveBadge(
-    message: { type: "removeBadge"; tabId: number },
+    tabId: number | undefined,
     sendResponse: (response: { success: boolean }) => void,
 ) {
-    removeBadge(message.tabId);
+    removeBadge(tabId);
     return sendResponse({ success: true });
 }
 
@@ -192,13 +192,21 @@ function handleSetBadge(
     return sendResponse({ success: true });
 }
 
-chrome.tabs.onUpdated.addListener((tabId, _changeInfo, tab) => {
-    if (!tab.url) return;
+const lastUrlByTab = new Map<number, string>();
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (changeInfo.status !== "complete") return;
+    if (!tab.url || tab.url === lastUrlByTab.get(tabId)) return;
+    lastUrlByTab.set(tabId, tab.url);
     if (isYoutubePage(tab.url)) {
         void showBadge(tabId);
     } else {
         removeBadge(tabId);
     }
+});
+
+// Clean up map entries when a tab is closed to avoid memory leaks
+chrome.tabs.onRemoved.addListener((tabId) => {
+    lastUrlByTab.delete(tabId);
 });
 
 async function showBadge(tabId: number) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -10,20 +10,21 @@ import type {
     YoutubeData,
 } from "@app-types/types";
 import { clearMediaCache, clearSyncCache, getFromStorage, saveToStorage } from "@lib/cache";
-import { addBadge, clearBadge } from "@/badge";
+import { badgeFormatter, removeBadge, setBadge } from "@/badge";
 import {
+    extractYtInitialResponse,
     parseDataFromYtInitial,
     parseVideoFormats,
-    extractYtInitialResponse,
     parseLiveStreamInfo,
     getThumbnailUrl,
 } from "@lib/youtube";
 import { getTwitchLiveResponse, getTwitchVodResponse } from "@lib/twitch";
 import { getKickLiveResponse, getKickVodResponse } from "@lib/kick";
+import { isYoutubePage } from "./lib/utils";
+import { getTotalUsageForDate, getUsageByDay, utcDateKey } from "./lib/analyticsUtils";
 
 chrome.runtime.onMessage.addListener((message: FrontEndMessage, sender, sendResponse) => {
     void handleMessage(message, sender, sendResponse);
-    // Synchronously return true to indicate that sendResponse will be called asynchronously
     return true;
 });
 
@@ -43,11 +44,11 @@ async function handleMessage(
     const tabId = getTabId(sender, message);
 
     switch (message.type) {
-        case "clearBadge": {
-            return handleClearBadge(tabId, sendResponse);
+        case "removeBadge": {
+            return handleRemoveBadge(message, sendResponse);
         }
         case "setBadge": {
-            return handleSetBadge(tabId, sendResponse);
+            return handleSetBadge(message, tabId, sendResponse);
         }
         case "youtubeVideo": {
             return await handleYoutube(message, sendResponse);
@@ -76,11 +77,9 @@ async function handleYoutube(
         if (!videoTag) {
             throw new Error("No video tag provided");
         }
-        clearBadge(message.tabId);
 
         const cached = await getFromStorage("youtube", videoTag);
         if (cached) {
-            addBadge(message.tabId);
             return sendResponse({
                 success: true,
                 data: cached.data,
@@ -104,7 +103,7 @@ async function handleYoutube(
             };
             await saveToStorage(videoTag, data, "youtube");
 
-            sendResponse({
+            return sendResponse({
                 success: true,
                 data,
             });
@@ -120,16 +119,12 @@ async function handleYoutube(
                 thumbnailUrl: getThumbnailUrl(rawData),
             };
             await saveToStorage(videoTag, youtubeData, "youtube");
-            addBadge(message.tabId);
             return sendResponse({
                 success: true,
                 data: youtubeData,
             });
         }
-
-        addBadge(message.tabId);
     } catch (err) {
-        clearBadge(message.tabId);
         return sendResponse({
             success: false,
             message: err instanceof Error ? err.message : "Unknown error",
@@ -180,18 +175,36 @@ chrome.runtime.onInstalled.addListener((details) => {
     }
 });
 
-function handleClearBadge(
-    tabId: number | undefined,
+function handleRemoveBadge(
+    message: { type: "removeBadge"; tabId: number },
     sendResponse: (response: { success: boolean }) => void,
 ) {
-    clearBadge(tabId);
+    removeBadge(message.tabId);
     return sendResponse({ success: true });
 }
 
 function handleSetBadge(
+    message: { type: "setBadge"; text: string },
     tabId: number | undefined,
     sendResponse: (response: { success: boolean }) => void,
 ) {
-    addBadge(tabId);
+    setBadge(message.text, tabId);
     return sendResponse({ success: true });
+}
+
+chrome.tabs.onUpdated.addListener((tabId, _changeInfo, tab) => {
+    if (!tab.url) return;
+    if (isYoutubePage(tab.url)) {
+        void showBadge(tabId);
+    } else {
+        removeBadge(tabId);
+    }
+});
+
+async function showBadge(tabId: number) {
+    const date = utcDateKey(new Date());
+    const usageByDay = await getUsageByDay();
+    const total = getTotalUsageForDate(usageByDay, date);
+
+    setBadge(badgeFormatter(total), tabId);
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -117,6 +117,7 @@ async function handleYoutube(
                 title: rawData.videoDetails.title,
                 id: rawData.videoDetails.videoId,
                 thumbnailUrl: getThumbnailUrl(rawData),
+                channelName: rawData.videoDetails.author,
             };
             await saveToStorage(videoTag, youtubeData, "youtube");
             return sendResponse({

--- a/src/badge.ts
+++ b/src/badge.ts
@@ -1,22 +1,6 @@
-// export function addBadge(tabId: number | undefined) {
-//     // if (!tabId) return;
-//     // void chrome.action.setBadgeText({
-//     //     tabId: tabId,
-//     //     text: "✓",
-//     // });
-//     // void chrome.action.setBadgeBackgroundColor({
-//     //     tabId: tabId,
-//     //     color: "#28a745",
-//     // });
-// }
-
-import { getTotalUsageForDate, type UsageByDay } from "./lib/analyticsUtils";
-import { sendMessageToBackground } from "./runtime";
-
-// export function clearBadge(tabId: number | undefined) {
-//     // if (!tabId) return;
-//     // void chrome.action.setBadgeText({ tabId, text: "" });
-// }
+import { getTotalUsageForDate } from "@lib/analyticsUtils";
+import type { UsageByDay } from "@lib/analyticsUtils";
+import { sendMessageToBackground } from "@/runtime";
 
 export function removeBadge(tabId: number | undefined) {
     if (!tabId) return;
@@ -24,13 +8,11 @@ export function removeBadge(tabId: number | undefined) {
 }
 
 export function setBadge(text: string, tabId: number | undefined) {
-    console.log(`Setting badge to "${text}"`);
     void chrome.action.setBadgeText({
         tabId,
         text,
     });
     void chrome.action.setBadgeBackgroundColor({ tabId, color: "rgb(102, 126, 234)" });
-    void chrome.action.setBadgeTextColor({ tabId, color: "#0c0303" });
 }
 
 export function updateBadge(usageByDay: UsageByDay, date: string) {

--- a/src/badge.ts
+++ b/src/badge.ts
@@ -1,16 +1,49 @@
-export function addBadge(tabId: number | undefined) {
+// export function addBadge(tabId: number | undefined) {
+//     // if (!tabId) return;
+//     // void chrome.action.setBadgeText({
+//     //     tabId: tabId,
+//     //     text: "✓",
+//     // });
+//     // void chrome.action.setBadgeBackgroundColor({
+//     //     tabId: tabId,
+//     //     color: "#28a745",
+//     // });
+// }
+
+import { getTotalUsageForDate, type UsageByDay } from "./lib/analyticsUtils";
+import { sendMessageToBackground } from "./runtime";
+
+// export function clearBadge(tabId: number | undefined) {
+//     // if (!tabId) return;
+//     // void chrome.action.setBadgeText({ tabId, text: "" });
+// }
+
+export function removeBadge(tabId: number | undefined) {
     if (!tabId) return;
+    void chrome.action.setBadgeText({ tabId, text: "" });
+}
+
+export function setBadge(text: string, tabId: number | undefined) {
+    console.log(`Setting badge to "${text}"`);
     void chrome.action.setBadgeText({
-        tabId: tabId,
-        text: "✓",
+        tabId,
+        text,
     });
-    void chrome.action.setBadgeBackgroundColor({
-        tabId: tabId,
-        color: "#28a745",
+    void chrome.action.setBadgeBackgroundColor({ tabId, color: "rgb(102, 126, 234)" });
+    void chrome.action.setBadgeTextColor({ tabId, color: "#0c0303" });
+}
+
+export function updateBadge(usageByDay: UsageByDay, date: string) {
+    const total = getTotalUsageForDate(usageByDay, date);
+    void sendMessageToBackground({
+        type: "setBadge",
+        text: badgeFormatter(total),
     });
 }
 
-export function clearBadge(tabId: number | undefined) {
-    if (!tabId) return;
-    void chrome.action.setBadgeText({ tabId, text: "" });
+export function badgeFormatter(bytes: number) {
+    if (bytes < 1024) return `${bytes}B`;
+    else if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}K`;
+    else if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)}M`;
+    else return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}G`;
 }

--- a/src/components/analytics/analytics.tsx
+++ b/src/components/analytics/analytics.tsx
@@ -110,7 +110,11 @@ export default function Analytics() {
     return (
         <div className="analytics-page">
             <div className="analytics-header">
-                <img className="analytics-icon" src="./public/icons/icon-32.png" />
+                <img
+                    className="analytics-icon"
+                    src="./public/icons/icon-32.png"
+                    alt="Analytics Icon"
+                />
                 <span>Usage Analytics for YouTube</span>
             </div>
             <div className="analytics-body">

--- a/src/components/analytics/analytics.tsx
+++ b/src/components/analytics/analytics.tsx
@@ -126,7 +126,7 @@ export default function Analytics() {
                     </Link>
                     <Link to="/week" className="stats-card-link">
                         <div className="stats-card">
-                            <div className="stat-label">This Week: </div>
+                            <div className="stat-label">Last 7 Days: </div>
                             <div className="stat-value">
                                 {formatBytes(thisWeekUsage(usage))}
                                 <div className="view-details">View Details</div>
@@ -135,7 +135,7 @@ export default function Analytics() {
                     </Link>
                     <Link to="/month" className="stats-card-link">
                         <div className="stats-card">
-                            <div className="stat-label">This Month: </div>
+                            <div className="stat-label">Last 30 Days: </div>
                             <div className="stat-value">
                                 {formatBytes(thisMonthUsage(usage))}
                                 <div className="view-details">View Details</div>

--- a/src/components/analytics/analytics.tsx
+++ b/src/components/analytics/analytics.tsx
@@ -109,7 +109,10 @@ export default function Analytics() {
 
     return (
         <div className="analytics-page">
-            <div className="analytics-header">TubeSize Usage Analytics for YouTube</div>
+            <div className="analytics-header">
+                <img className="analytics-icon" src="./public/icons/icon-32.png" />
+                <span>Usage Analytics for YouTube</span>
+            </div>
             <div className="analytics-body">
                 <div className="stats-row">
                     <Link to="/today" className="stats-card-link">

--- a/src/components/analytics/analytics.tsx
+++ b/src/components/analytics/analytics.tsx
@@ -110,11 +110,7 @@ export default function Analytics() {
     return (
         <div className="analytics-page">
             <div className="analytics-header">
-                <img
-                    className="analytics-icon"
-                    src="./public/icons/icon-32.png"
-                    alt="Analytics Icon"
-                />
+                <img className="analytics-icon" src="/icons/icon-32.png" alt="Analytics Icon" />
                 <span>Usage Analytics for YouTube</span>
             </div>
             <div className="analytics-body">

--- a/src/components/analytics/chart.tsx
+++ b/src/components/analytics/chart.tsx
@@ -32,7 +32,8 @@ export default function Chart({ usage }: { usage: UsageByDay }) {
         return {
             date,
             value:
-                Object.values(videos).reduce((total, video) => total + video.usage, 0) / 1_000_000,
+                Object.values(videos).reduce((total, video) => total + video.usage, 0) /
+                (1024 * 1024),
         };
     });
     return (

--- a/src/components/analytics/lifeTimeUsage.tsx
+++ b/src/components/analytics/lifeTimeUsage.tsx
@@ -17,7 +17,7 @@ function getLifeTimeDateRange(usageByDay: UsageByDay) {
     const startDate = new Date(dates[0]!);
     const endDate = new Date(dates.at(-1)!);
 
-    return `${startDate.toLocaleDateString()} - ${endDate.toLocaleDateString()}`;
+    return `${startDate.toDateString().split(" ").slice(1).join(" ")} -> ${endDate.toDateString().split(" ").slice(1).join(" ")}`;
 }
 
 function getTotalUsage(lifeTimeUsage: UsageByDay) {
@@ -85,8 +85,9 @@ export default function LifetimeUsage() {
                             </thead>
                             <tbody>
                                 {Object.entries(lifeTimeUsage).map(([date, videos]) =>
-                                    Object.entries(videos).map(
-                                        ([videoTag, { usage, title, thumbnailUrl }]) => {
+                                    Object.entries(videos)
+                                        .sort((a, b) => b[1].usage - a[1].usage)
+                                        .map(([videoTag, { usage, title, thumbnailUrl }]) => {
                                             const url = getVideoUrl(videoTag);
 
                                             const imageUrl =
@@ -119,8 +120,7 @@ export default function LifetimeUsage() {
                                                     <td>{formatBytes(usage)}</td>
                                                 </tr>
                                             );
-                                        },
-                                    ),
+                                        }),
                                 )}
                             </tbody>
                         </table>

--- a/src/components/analytics/lifeTimeUsage.tsx
+++ b/src/components/analytics/lifeTimeUsage.tsx
@@ -87,40 +87,54 @@ export default function LifetimeUsage() {
                                 {Object.entries(lifeTimeUsage).map(([date, videos]) =>
                                     Object.entries(videos)
                                         .sort((a, b) => b[1].usage - a[1].usage)
-                                        .map(([videoTag, { usage, title, thumbnailUrl }]) => {
-                                            const url = getVideoUrl(videoTag);
+                                        .map(
+                                            ([
+                                                videoTag,
+                                                { usage, title, thumbnailUrl, channelName },
+                                            ]) => {
+                                                const url = getVideoUrl(videoTag);
 
-                                            const imageUrl =
-                                                thumbnailUrl ||
-                                                "https://placehold.co/213x120?text=Unknown&font=roboto";
+                                                const imageUrl =
+                                                    thumbnailUrl ||
+                                                    "https://placehold.co/213x120?text=Unknown&font=roboto";
 
-                                            const displayTitle = title || "Youtube";
+                                                const displayTitle = title || "Youtube";
 
-                                            return (
-                                                <tr key={`${date}-${videoTag}`}>
-                                                    <td className="index">{index++ + 1}</td>
+                                                return (
+                                                    <tr key={`${date}-${videoTag}`}>
+                                                        <td className="index">{index++ + 1}</td>
 
-                                                    <td>
-                                                        <a
-                                                            className="video-title-cell"
-                                                            target="_blank"
-                                                            rel="noreferrer"
-                                                            href={url}
-                                                        >
-                                                            <img
-                                                                className="video-thumbnail"
-                                                                src={imageUrl}
-                                                                alt="thumbnail"
-                                                            />
+                                                        <td>
+                                                            <a
+                                                                className="video-title-cell"
+                                                                target="_blank"
+                                                                rel="noreferrer"
+                                                                href={url}
+                                                            >
+                                                                <img
+                                                                    className="video-thumbnail"
+                                                                    src={imageUrl}
+                                                                    alt="thumbnail"
+                                                                />
 
-                                                            {displayTitle}
-                                                        </a>
-                                                    </td>
+                                                                <div className="video-info">
+                                                                    <span className="video-title">
+                                                                        {displayTitle}
+                                                                    </span>
+                                                                    {channelName && (
+                                                                        <span className="video-channel">
+                                                                            {channelName}
+                                                                        </span>
+                                                                    )}
+                                                                </div>
+                                                            </a>
+                                                        </td>
 
-                                                    <td>{formatBytes(usage)}</td>
-                                                </tr>
-                                            );
-                                        }),
+                                                        <td>{formatBytes(usage)}</td>
+                                                    </tr>
+                                                );
+                                            },
+                                        ),
                                 )}
                             </tbody>
                         </table>

--- a/src/components/analytics/monthUsage.tsx
+++ b/src/components/analytics/monthUsage.tsx
@@ -98,40 +98,54 @@ export default function MonthUsage() {
                                 {Object.entries(monthUsage).map(([date, videos]) =>
                                     Object.entries(videos)
                                         .sort((a, b) => b[1].usage - a[1].usage)
-                                        .map(([videoTag, { usage, title, thumbnailUrl }]) => {
-                                            const url = getVideoUrl(videoTag);
+                                        .map(
+                                            ([
+                                                videoTag,
+                                                { usage, title, thumbnailUrl, channelName },
+                                            ]) => {
+                                                const url = getVideoUrl(videoTag);
 
-                                            const imageUrl =
-                                                thumbnailUrl ||
-                                                "https://placehold.co/213x120?text=Unknown&font=roboto";
+                                                const imageUrl =
+                                                    thumbnailUrl ||
+                                                    "https://placehold.co/213x120?text=Unknown&font=roboto";
 
-                                            const displayTitle = title || "Youtube";
+                                                const displayTitle = title || "Youtube";
 
-                                            return (
-                                                <tr key={`${date}-${videoTag}`}>
-                                                    <td className="index">{index++ + 1}</td>
+                                                return (
+                                                    <tr key={`${date}-${videoTag}`}>
+                                                        <td className="index">{index++ + 1}</td>
 
-                                                    <td>
-                                                        <a
-                                                            className="video-title-cell"
-                                                            target="_blank"
-                                                            rel="noreferrer"
-                                                            href={url}
-                                                        >
-                                                            <img
-                                                                className="video-thumbnail"
-                                                                src={imageUrl}
-                                                                alt="thumbnail"
-                                                            />
+                                                        <td>
+                                                            <a
+                                                                className="video-title-cell"
+                                                                target="_blank"
+                                                                rel="noreferrer"
+                                                                href={url}
+                                                            >
+                                                                <img
+                                                                    className="video-thumbnail"
+                                                                    src={imageUrl}
+                                                                    alt="thumbnail"
+                                                                />
 
-                                                            {displayTitle}
-                                                        </a>
-                                                    </td>
+                                                                <div className="video-info">
+                                                                    <span className="video-title">
+                                                                        {displayTitle}
+                                                                    </span>
+                                                                    {channelName && (
+                                                                        <span className="video-channel">
+                                                                            {channelName}
+                                                                        </span>
+                                                                    )}
+                                                                </div>
+                                                            </a>
+                                                        </td>
 
-                                                    <td>{formatBytes(usage)}</td>
-                                                </tr>
-                                            );
-                                        }),
+                                                        <td>{formatBytes(usage)}</td>
+                                                    </tr>
+                                                );
+                                            },
+                                        ),
                                 )}
                             </tbody>
                         </table>

--- a/src/components/analytics/monthUsage.tsx
+++ b/src/components/analytics/monthUsage.tsx
@@ -37,7 +37,7 @@ function getMonthUsage(usageByDay: UsageByDay) {
 function formatDate(month: Date[]) {
     const startDate = new Date(month[0]!);
     const endDate = new Date(month.at(-1)!);
-    return `${startDate.toLocaleDateString()} - ${endDate.toLocaleDateString()}`;
+    return `${startDate.toDateString().split(" ").slice(1).join(" ")} -> ${endDate.toDateString().split(" ").slice(1).join(" ")}`;
 }
 
 function getVideoUrl(videoTag: string) {
@@ -96,8 +96,9 @@ export default function MonthUsage() {
                             </thead>
                             <tbody>
                                 {Object.entries(monthUsage).map(([date, videos]) =>
-                                    Object.entries(videos).map(
-                                        ([videoTag, { usage, title, thumbnailUrl }]) => {
+                                    Object.entries(videos)
+                                        .sort((a, b) => b[1].usage - a[1].usage)
+                                        .map(([videoTag, { usage, title, thumbnailUrl }]) => {
                                             const url = getVideoUrl(videoTag);
 
                                             const imageUrl =
@@ -130,8 +131,7 @@ export default function MonthUsage() {
                                                     <td>{formatBytes(usage)}</td>
                                                 </tr>
                                             );
-                                        },
-                                    ),
+                                        }),
                                 )}
                             </tbody>
                         </table>

--- a/src/components/analytics/todayUsage.tsx
+++ b/src/components/analytics/todayUsage.tsx
@@ -81,35 +81,49 @@ export default function TodayUsage() {
                             <tbody>
                                 {Object.entries(todayUsage)
                                     .sort((a, b) => b[1].usage - a[1].usage)
-                                    .map(([videoTag, { usage, title, thumbnailUrl }], index) => {
-                                        const url = getVideoUrl(videoTag);
-                                        const imageUrl =
-                                            thumbnailUrl ||
-                                            "https://placehold.co/213x120?text=Unknown&font=roboto";
-                                        const displayTitle = title || "Youtube";
+                                    .map(
+                                        (
+                                            [videoTag, { usage, title, thumbnailUrl, channelName }],
+                                            index,
+                                        ) => {
+                                            const url = getVideoUrl(videoTag);
+                                            const imageUrl =
+                                                thumbnailUrl ||
+                                                "https://placehold.co/213x120?text=Unknown&font=roboto";
+                                            const displayTitle = title || "Youtube";
 
-                                        return (
-                                            <tr key={videoTag}>
-                                                <td className="index">{index + 1}</td>
-                                                <td>
-                                                    <a
-                                                        className="video-title-cell"
-                                                        target="_blank"
-                                                        rel="noreferrer"
-                                                        href={url}
-                                                    >
-                                                        <img
-                                                            className="video-thumbnail"
-                                                            src={imageUrl}
-                                                            alt="thumbnail"
-                                                        />
-                                                        {displayTitle}
-                                                    </a>
-                                                </td>
-                                                <td>{formatBytes(usage)}</td>
-                                            </tr>
-                                        );
-                                    })}
+                                            return (
+                                                <tr key={videoTag}>
+                                                    <td className="index">{index + 1}</td>
+                                                    <td>
+                                                        <a
+                                                            className="video-title-cell"
+                                                            target="_blank"
+                                                            rel="noreferrer"
+                                                            href={url}
+                                                        >
+                                                            <img
+                                                                className="video-thumbnail"
+                                                                src={imageUrl}
+                                                                alt="thumbnail"
+                                                            />
+                                                            <div className="video-info">
+                                                                <span className="video-title">
+                                                                    {displayTitle}
+                                                                </span>
+                                                                {channelName && (
+                                                                    <span className="video-channel">
+                                                                        {channelName}
+                                                                    </span>
+                                                                )}
+                                                            </div>
+                                                        </a>
+                                                    </td>
+                                                    <td>{formatBytes(usage)}</td>
+                                                </tr>
+                                            );
+                                        },
+                                    )}
                             </tbody>
                         </table>
                         {isEmptyUsageByVideo(todayUsage) && (

--- a/src/components/analytics/todayUsage.tsx
+++ b/src/components/analytics/todayUsage.tsx
@@ -79,8 +79,9 @@ export default function TodayUsage() {
                                 </tr>
                             </thead>
                             <tbody>
-                                {Object.entries(todayUsage).map(
-                                    ([videoTag, { usage, title, thumbnailUrl }], index) => {
+                                {Object.entries(todayUsage)
+                                    .sort((a, b) => b[1].usage - a[1].usage)
+                                    .map(([videoTag, { usage, title, thumbnailUrl }], index) => {
                                         const url = getVideoUrl(videoTag);
                                         const imageUrl =
                                             thumbnailUrl ||
@@ -108,8 +109,7 @@ export default function TodayUsage() {
                                                 <td>{formatBytes(usage)}</td>
                                             </tr>
                                         );
-                                    },
-                                )}
+                                    })}
                             </tbody>
                         </table>
                         {isEmptyUsageByVideo(todayUsage) && (

--- a/src/components/analytics/usageDetails.tsx
+++ b/src/components/analytics/usageDetails.tsx
@@ -75,37 +75,51 @@ export function UsageDetails() {
                             {todayUsage &&
                                 Object.entries(todayUsage)
                                     .sort((a, b) => b[1].usage - a[1].usage)
-                                    .map(([videoTag, { usage, title, thumbnailUrl }], index) => {
-                                        const url = getVideoUrl(videoTag);
-                                        const imageUrl =
-                                            thumbnailUrl ||
-                                            "https://placehold.co/213x120?text=Unknown&font=roboto";
-                                        const displayTitle = title || "Youtube";
+                                    .map(
+                                        (
+                                            [videoTag, { usage, title, thumbnailUrl, channelName }],
+                                            index,
+                                        ) => {
+                                            const url = getVideoUrl(videoTag);
+                                            const imageUrl =
+                                                thumbnailUrl ||
+                                                "https://placehold.co/213x120?text=Unknown&font=roboto";
+                                            const displayTitle = title || "Youtube";
 
-                                        return (
-                                            <tr key={videoTag}>
-                                                <td className="index">{index + 1}</td>
-                                                <td>
-                                                    <div className="video-cell">
-                                                        <a
-                                                            className="video-title-cell"
-                                                            target="_blank"
-                                                            rel="noreferrer"
-                                                            href={url}
-                                                        >
-                                                            <img
-                                                                className="video-thumbnail"
-                                                                src={imageUrl}
-                                                                alt="thumbnail"
-                                                            />
-                                                            {displayTitle}
-                                                        </a>
-                                                    </div>
-                                                </td>
-                                                <td>{formatBytes(usage)}</td>
-                                            </tr>
-                                        );
-                                    })}
+                                            return (
+                                                <tr key={videoTag}>
+                                                    <td className="index">{index + 1}</td>
+                                                    <td>
+                                                        <div className="video-cell">
+                                                            <a
+                                                                className="video-title-cell"
+                                                                target="_blank"
+                                                                rel="noreferrer"
+                                                                href={url}
+                                                            >
+                                                                <img
+                                                                    className="video-thumbnail"
+                                                                    src={imageUrl}
+                                                                    alt="thumbnail"
+                                                                />
+                                                                <div className="video-info">
+                                                                    <span className="video-title">
+                                                                        {displayTitle}
+                                                                    </span>
+                                                                    {channelName && (
+                                                                        <span className="video-channel">
+                                                                            {channelName}
+                                                                        </span>
+                                                                    )}
+                                                                </div>
+                                                            </a>
+                                                        </div>
+                                                    </td>
+                                                    <td>{formatBytes(usage)}</td>
+                                                </tr>
+                                            );
+                                        },
+                                    )}
                         </tbody>
                     </table>
                 </div>

--- a/src/components/analytics/usageDetails.tsx
+++ b/src/components/analytics/usageDetails.tsx
@@ -68,8 +68,9 @@ export function UsageDetails() {
                             </tr>
                         </thead>
                         <tbody>
-                            {Object.entries(todayUsage).map(
-                                ([videoTag, { usage, title, thumbnailUrl }], index) => {
+                            {Object.entries(todayUsage)
+                                .sort((a, b) => b[1].usage - a[1].usage)
+                                .map(([videoTag, { usage, title, thumbnailUrl }], index) => {
                                     const url = getVideoUrl(videoTag);
                                     const imageUrl =
                                         thumbnailUrl ||
@@ -99,8 +100,7 @@ export function UsageDetails() {
                                             <td>{formatBytes(usage)}</td>
                                         </tr>
                                     );
-                                },
-                            )}
+                                })}
                         </tbody>
                     </table>
                 </div>

--- a/src/components/analytics/usageDetails.tsx
+++ b/src/components/analytics/usageDetails.tsx
@@ -33,7 +33,7 @@ export function UsageDetails() {
             setTodayUsage(date ? usageByDay[date] : undefined);
         })();
     }, [date]);
-    if (!todayUsage || !date) return;
+    if (!date) return;
     return (
         <div className="usage-details">
             <div className="usage-details-header">
@@ -46,16 +46,20 @@ export function UsageDetails() {
                     ← Back to Analytics
                 </button>
                 <div className="usage-details-title">{`${formatDate(date)}`}</div>
-                <div className="usage-details-summary">
-                    <div className="summary-item">
-                        <div className="summary-item-header">{"Total Data Used"}</div>
-                        <div className="number">{formatBytes(getTodayTotalUsage(todayUsage))}</div>
+                {todayUsage && (
+                    <div className="usage-details-summary">
+                        <div className="summary-item">
+                            <div className="summary-item-header">{"Total Data Used"}</div>
+                            <div className="number">
+                                {formatBytes(getTodayTotalUsage(todayUsage))}
+                            </div>
+                        </div>
+                        <div className="summary-item">
+                            <div className="summary-item-header">{"Videos Watched"}</div>
+                            <div className="number">{Object.entries(todayUsage).length}</div>
+                        </div>
                     </div>
-                    <div className="summary-item">
-                        <div className="summary-item-header">{"Videos Watched"}</div>
-                        <div className="number">{Object.entries(todayUsage).length}</div>
-                    </div>
-                </div>
+                )}
             </div>
             <div className="body-wrapper">
                 <div className="usage-details-list">
@@ -68,39 +72,40 @@ export function UsageDetails() {
                             </tr>
                         </thead>
                         <tbody>
-                            {Object.entries(todayUsage)
-                                .sort((a, b) => b[1].usage - a[1].usage)
-                                .map(([videoTag, { usage, title, thumbnailUrl }], index) => {
-                                    const url = getVideoUrl(videoTag);
-                                    const imageUrl =
-                                        thumbnailUrl ||
-                                        "https://placehold.co/213x120?text=Unknown&font=roboto";
-                                    const displayTitle = title || "Youtube";
+                            {todayUsage &&
+                                Object.entries(todayUsage)
+                                    .sort((a, b) => b[1].usage - a[1].usage)
+                                    .map(([videoTag, { usage, title, thumbnailUrl }], index) => {
+                                        const url = getVideoUrl(videoTag);
+                                        const imageUrl =
+                                            thumbnailUrl ||
+                                            "https://placehold.co/213x120?text=Unknown&font=roboto";
+                                        const displayTitle = title || "Youtube";
 
-                                    return (
-                                        <tr key={videoTag}>
-                                            <td className="index">{index + 1}</td>
-                                            <td>
-                                                <div className="video-cell">
-                                                    <a
-                                                        className="video-title-cell"
-                                                        target="_blank"
-                                                        rel="noreferrer"
-                                                        href={url}
-                                                    >
-                                                        <img
-                                                            className="video-thumbnail"
-                                                            src={imageUrl}
-                                                            alt="thumbnail"
-                                                        />
-                                                        {displayTitle}
-                                                    </a>
-                                                </div>
-                                            </td>
-                                            <td>{formatBytes(usage)}</td>
-                                        </tr>
-                                    );
-                                })}
+                                        return (
+                                            <tr key={videoTag}>
+                                                <td className="index">{index + 1}</td>
+                                                <td>
+                                                    <div className="video-cell">
+                                                        <a
+                                                            className="video-title-cell"
+                                                            target="_blank"
+                                                            rel="noreferrer"
+                                                            href={url}
+                                                        >
+                                                            <img
+                                                                className="video-thumbnail"
+                                                                src={imageUrl}
+                                                                alt="thumbnail"
+                                                            />
+                                                            {displayTitle}
+                                                        </a>
+                                                    </div>
+                                                </td>
+                                                <td>{formatBytes(usage)}</td>
+                                            </tr>
+                                        );
+                                    })}
                         </tbody>
                     </table>
                 </div>

--- a/src/components/analytics/weekUsage.tsx
+++ b/src/components/analytics/weekUsage.tsx
@@ -98,40 +98,54 @@ export default function WeekUsage() {
                                 {Object.entries(weekUsage).map(([date, videos]) =>
                                     Object.entries(videos)
                                         .sort((a, b) => b[1].usage - a[1].usage)
-                                        .map(([videoTag, { usage, title, thumbnailUrl }]) => {
-                                            const url = getVideoUrl(videoTag);
+                                        .map(
+                                            ([
+                                                videoTag,
+                                                { usage, title, thumbnailUrl, channelName },
+                                            ]) => {
+                                                const url = getVideoUrl(videoTag);
 
-                                            const imageUrl =
-                                                thumbnailUrl ||
-                                                "https://placehold.co/213x120?text=Unknown&font=roboto";
+                                                const imageUrl =
+                                                    thumbnailUrl ||
+                                                    "https://placehold.co/213x120?text=Unknown&font=roboto";
 
-                                            const displayTitle = title || "Youtube";
+                                                const displayTitle = title || "Youtube";
 
-                                            return (
-                                                <tr key={`${date}-${videoTag}`}>
-                                                    <td className="index">{index++ + 1}</td>
+                                                return (
+                                                    <tr key={`${date}-${videoTag}`}>
+                                                        <td className="index">{index++ + 1}</td>
 
-                                                    <td>
-                                                        <a
-                                                            className="video-title-cell"
-                                                            target="_blank"
-                                                            rel="noreferrer"
-                                                            href={url}
-                                                        >
-                                                            <img
-                                                                className="video-thumbnail"
-                                                                src={imageUrl}
-                                                                alt="thumbnail"
-                                                            />
+                                                        <td>
+                                                            <a
+                                                                className="video-title-cell"
+                                                                target="_blank"
+                                                                rel="noreferrer"
+                                                                href={url}
+                                                            >
+                                                                <img
+                                                                    className="video-thumbnail"
+                                                                    src={imageUrl}
+                                                                    alt="thumbnail"
+                                                                />
 
-                                                            {displayTitle}
-                                                        </a>
-                                                    </td>
+                                                                <div className="video-info">
+                                                                    <span className="video-title">
+                                                                        {displayTitle}
+                                                                    </span>
+                                                                    {channelName && (
+                                                                        <span className="video-channel">
+                                                                            {channelName}
+                                                                        </span>
+                                                                    )}
+                                                                </div>
+                                                            </a>
+                                                        </td>
 
-                                                    <td>{formatBytes(usage)}</td>
-                                                </tr>
-                                            );
-                                        }),
+                                                        <td>{formatBytes(usage)}</td>
+                                                    </tr>
+                                                );
+                                            },
+                                        ),
                                 )}
                             </tbody>
                         </table>

--- a/src/components/analytics/weekUsage.tsx
+++ b/src/components/analytics/weekUsage.tsx
@@ -37,7 +37,7 @@ function getWeekUsage(usageByDay: UsageByDay) {
 function formatDate(week: Date[]) {
     const startDate = new Date(week[0]!);
     const endDate = new Date(week.at(-1)!);
-    return `${startDate.toLocaleDateString()} - ${endDate.toLocaleDateString()}`;
+    return `${startDate.toDateString().split(" ").slice(1).join(" ")} -> ${endDate.toDateString().split(" ").slice(1).join(" ")}`;
 }
 
 function getVideoUrl(videoTag: string) {
@@ -96,8 +96,9 @@ export default function WeekUsage() {
                             </thead>
                             <tbody>
                                 {Object.entries(weekUsage).map(([date, videos]) =>
-                                    Object.entries(videos).map(
-                                        ([videoTag, { usage, title, thumbnailUrl }]) => {
+                                    Object.entries(videos)
+                                        .sort((a, b) => b[1].usage - a[1].usage)
+                                        .map(([videoTag, { usage, title, thumbnailUrl }]) => {
                                             const url = getVideoUrl(videoTag);
 
                                             const imageUrl =
@@ -130,8 +131,7 @@ export default function WeekUsage() {
                                                     <td>{formatBytes(usage)}</td>
                                                 </tr>
                                             );
-                                        },
-                                    ),
+                                        }),
                                 )}
                             </tbody>
                         </table>

--- a/src/components/kickFormats.tsx
+++ b/src/components/kickFormats.tsx
@@ -1,7 +1,7 @@
 import type { KickData } from "@app-types/types";
 import useCurrentQuality from "@hooks/useCurrentQuality";
 import useTab from "@hooks/useTab";
-import FormatItem from "./formatItem";
+import FormatItem from "@components/formatItem";
 
 export default function KickFormats({ data }: { data: KickData }) {
     const { tabId, tabUrl } = useTab();

--- a/src/components/popupUsage.tsx
+++ b/src/components/popupUsage.tsx
@@ -1,16 +1,13 @@
 import { totalSizeVideoDisplay } from "@lib/formatting";
 import { useEffect, useState } from "react";
-import { getUsageByDay, utcDateKey } from "@lib/analyticsUtils";
+import { getTotalUsageForDate, getUsageByDay, utcDateKey } from "@lib/analyticsUtils";
 
 async function getTodaysTotalUsage(tabId: number | undefined) {
     if (!tabId) return;
     const usageByDay = await getUsageByDay();
     const date = utcDateKey(new Date());
 
-    let total = 0;
-    for (const [_videoTag, { usage }] of Object.entries(usageByDay[date] ?? {})) {
-        total += usage;
-    }
+    const total = getTotalUsageForDate(usageByDay, date);
     return total;
 }
 
@@ -37,8 +34,12 @@ export default function PopupUsage({ tabId }: { tabId: number | undefined }) {
         <>
             {todayUsage !== undefined && (
                 <div className="today-usage">
-                    <span>{"YouTube Usage Today: "}</span>
-                    <span className="today-usage-value">{totalSizeVideoDisplay(todayUsage)}</span>
+                    <button onClick={() => void chrome.tabs.create({ url: "#/today" })}>
+                        <span>{"YouTube Usage Today: "}</span>
+                        <span className="today-usage-value">
+                            {totalSizeVideoDisplay(todayUsage)}
+                        </span>
+                    </button>
                 </div>
             )}
         </>

--- a/src/content.ts
+++ b/src/content.ts
@@ -22,8 +22,8 @@ import {
     stopResolutionTracking,
 } from "@/resolution";
 import { getKickHtml, getKickStreamId } from "@lib/kick";
-import type { KickBackgroundResponse } from "./types/types";
-import { waitForElement } from "./lib/dom";
+import type { KickBackgroundResponse } from "@app-types/types";
+import { waitForElement } from "@lib/dom";
 
 function getCurrentUrl() {
     return globalThis.location.href;
@@ -32,7 +32,6 @@ function getCurrentUrl() {
 async function handlePageNavigation() {
     try {
         const url = getCurrentUrl();
-        void sendMessageToBackground({ type: "clearBadge" });
 
         if (!isYoutubePage(url) && !isTwitchPage(url) && !isKickPage(url)) {
             removeEventListeners();
@@ -129,13 +128,12 @@ chrome.runtime.onMessage.addListener(
         }
     },
 );
+
 /**
  * Returns the setting for the toaster threshold in MB per minute.
  * If the setting is not found or is invalid, it returns the default threshold defined in CONFIG.
- * @returns {number} The toaster threshold in MB per minute.
  * @throws Will throw an error if there is an issue retrieving the setting from cache.
  */
-
 async function initYoutube(videoTag: string) {
     const scriptsArray = [...document.scripts];
     const ytInitialPlayerResponse = scriptsArray.find((script) => {

--- a/src/lib/analyticsUtils.ts
+++ b/src/lib/analyticsUtils.ts
@@ -1,4 +1,4 @@
-import { getFromLocalCache } from "./cache";
+import { getFromLocalCache } from "@lib/cache";
 import { filesize } from "filesize";
 
 export type UsageByDay = {

--- a/src/lib/analyticsUtils.ts
+++ b/src/lib/analyticsUtils.ts
@@ -7,6 +7,7 @@ export type UsageByDay = {
             usage: number;
             title: string | undefined;
             thumbnailUrl: string | undefined;
+            channelName: string | undefined;
         };
     };
 };
@@ -16,6 +17,7 @@ export type UsageByVideo = {
         usage: number;
         title: string | undefined;
         thumbnailUrl: string | undefined;
+        channelName: string | undefined;
     };
 };
 export async function getUsageByDay(): Promise<UsageByDay> {

--- a/src/lib/analyticsUtils.ts
+++ b/src/lib/analyticsUtils.ts
@@ -75,6 +75,14 @@ export function getNumVideosWatched(usageByDay: UsageByDay) {
     return count;
 }
 
-export function formatBytes(bytes: number) {
-    return filesize(bytes, { base: 10, standard: "jedec", round: 2 });
+export function formatBytes(bytes: number, options?: { round: number }) {
+    return filesize(bytes, { base: 10, standard: "jedec", round: 2, ...options });
+}
+
+export function getTotalUsageForDate(usageByDay: UsageByDay, date: string) {
+    let total = 0;
+    for (const [_videoTag, { usage }] of Object.entries(usageByDay[date] ?? {})) {
+        total += usage;
+    }
+    return total;
 }

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,6 +1,6 @@
 import CONFIG from "@lib/constants";
 import type { KickData, OptionsMap, StorageData, TwitchData, YoutubeData } from "@app-types/types";
-import { utcDateKey } from "./analyticsUtils";
+import { utcDateKey } from "@lib/analyticsUtils";
 
 async function getCacheTTLSetting(): Promise<number> {
     const cacheTTL = (await getFromSyncCache("cacheTTL")) as number;

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -18,11 +18,6 @@ export function totalSizeLiveDisplay(sizePerSecondBytes: number, durationSeconds
     return `${totalSizeMB.toFixed(2)} MB`;
 }
 export function totalSizeVideoDisplay(totalSizeBytes: number): string {
-    // const totalSizeMB = totalSizeBytes / 1_000_000;
-    // if (totalSizeMB >= 1000) {
-    //     return `${(totalSizeMB / 1000).toFixed(2)} GB`;
-    // }
-    // return `${totalSizeMB.toFixed(2)} MB`;
     return filesize(totalSizeBytes, { base: 10, standard: "jedec", round: 2 });
 }
 

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -1,3 +1,5 @@
+import { filesize } from "filesize";
+
 export function perHourDisplay(sizePerSecondBytes: number): string {
     const sizePerHourMB = sizePerHour(sizePerSecondBytes);
     if (sizePerHourMB >= 1000) {
@@ -16,11 +18,12 @@ export function totalSizeLiveDisplay(sizePerSecondBytes: number, durationSeconds
     return `${totalSizeMB.toFixed(2)} MB`;
 }
 export function totalSizeVideoDisplay(totalSizeBytes: number): string {
-    const totalSizeMB = totalSizeBytes / 1_000_000;
-    if (totalSizeMB >= 1000) {
-        return `${(totalSizeMB / 1000).toFixed(2)} GB`;
-    }
-    return `${totalSizeMB.toFixed(2)} MB`;
+    // const totalSizeMB = totalSizeBytes / 1_000_000;
+    // if (totalSizeMB >= 1000) {
+    //     return `${(totalSizeMB / 1000).toFixed(2)} GB`;
+    // }
+    // return `${totalSizeMB.toFixed(2)} MB`;
+    return filesize(totalSizeBytes, { base: 10, standard: "jedec", round: 2 });
 }
 
 export function perMinuteDisplay(sizePerSecondBytes: number): string {

--- a/src/lib/hlsSize.ts
+++ b/src/lib/hlsSize.ts
@@ -1,8 +1,8 @@
 import type { StreamInfo } from "@app-types/types";
 import CONFIG from "@lib/constants";
 import type { Manifest, PlaylistItem } from "m3u8-parser";
-import { fetchMediaM3u8, mediaPlaylistUrlByHeight } from "./m3u8";
-import { filterM3u8 } from "./m3u8";
+import { fetchMediaM3u8, mediaPlaylistUrlByHeight } from "@lib/m3u8";
+import { filterM3u8 } from "@lib/m3u8";
 
 async function fetchActualSegments(
     segments: {

--- a/src/lib/kick.ts
+++ b/src/lib/kick.ts
@@ -1,9 +1,9 @@
 import { filterM3u8, parseM3U8 } from "@lib/m3u8";
 import type { PlaylistItem } from "m3u8-parser";
-import { fetchAndRetry } from "./utils";
-import { estimateHlsStreamSizes } from "./hlsSize";
+import { fetchAndRetry } from "@lib/utils";
+import { estimateHlsStreamSizes } from "@lib/hlsSize";
 import type { KickBackgroundResponse, KickLiveMessage, KickVodMessage } from "@app-types/types";
-import { kickPlaybackResponseSchema } from "./schema";
+import { kickPlaybackResponseSchema } from "@lib/schema";
 
 export async function getKickHtml(url: string): Promise<string> {
     const res = await fetchAndRetry(url, {

--- a/src/lib/m3u8.ts
+++ b/src/lib/m3u8.ts
@@ -1,6 +1,6 @@
 import { Parser } from "m3u8-parser";
 import type { Manifest, PlaylistItem } from "m3u8-parser";
-import { fetchAndRetry } from "./utils";
+import { fetchAndRetry } from "@lib/utils";
 import type { StreamInfo } from "@app-types/types";
 
 export function parseM3U8(m3u8Data: string): Manifest {

--- a/src/lib/twitch.ts
+++ b/src/lib/twitch.ts
@@ -9,11 +9,11 @@ import type {
 } from "@app-types/types";
 import type { PlaylistItem } from "m3u8-parser";
 import CONFIG from "@lib/constants";
-import { estimateHlsStreamSizes } from "./hlsSize";
+import { estimateHlsStreamSizes } from "@lib/hlsSize";
 import { filterM3u8, parseM3U8 } from "@lib/m3u8";
-import { getFromStorage, saveToStorage } from "./cache";
-import { fetchAndRetry } from "./utils";
-import { twitchGqlResponseSchema } from "./schema";
+import { getFromStorage, saveToStorage } from "@lib/cache";
+import { fetchAndRetry } from "@lib/utils";
+import { twitchGqlResponseSchema } from "@lib/schema";
 
 export async function getTwitchClientId(message: TwitchMessage): Promise<string> {
     const url =

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -6,7 +6,7 @@ import type {
 } from "@app-types/types";
 import { fetchAndRetry } from "@lib/utils";
 import CONFIG from "@lib/constants";
-import { ytInitialSchema } from "./schema";
+import { ytInitialSchema } from "@lib/schema";
 
 export function sizePerMinute(
     sizeInBytes: number,

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,7 +1,8 @@
 import { setToLocalCache } from "@lib/cache";
 import { delay, extractVideoTag } from "@lib/utils";
 import { getUsageByDay, utcDateKey } from "@lib/analyticsUtils";
-import { sendMessageToBackground } from "./runtime";
+import { sendMessageToBackground } from "@/runtime";
+import { updateBadge } from "./badge";
 
 let pendingUsage: number = 0;
 const observer = new PerformanceObserver((list) => {
@@ -16,11 +17,12 @@ function getCurrentTabUrl() {
 }
 
 void (async () => {
+    const CACHED_VIDEOS = new Set<string>();
     do {
         try {
             const videoTag = extractVideoTag(getCurrentTabUrl());
             if (!videoTag) {
-                await delay(10_000);
+                await delay(500);
                 continue;
             }
 
@@ -36,21 +38,24 @@ void (async () => {
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             const oldUsage = usageByDay?.[date]?.[videoTag]?.usage || 0;
 
-            usageByDay[date][videoTag].usage = oldUsage + pendingUsage;
-            const res = await sendMessageToBackground({
-                type: "youtubeVideo",
-                videoTag,
-            });
-            if (!res.success) {
-                console.error("Failed to get video title from background script.");
-                continue;
+            if (!CACHED_VIDEOS.has(videoTag)) {
+                const res = await sendMessageToBackground({
+                    type: "youtubeVideo",
+                    videoTag,
+                });
+                if (!res.success) {
+                    console.error("Failed to get video title from background script.");
+                    continue;
+                }
+
+                usageByDay[date][videoTag].title =
+                    res.data.type === "video" ? res.data.title : res.data.channelName || "Youtube";
+                usageByDay[date][videoTag].thumbnailUrl =
+                    res.data.thumbnailUrl || "https://www.youtube.com/img/desktop/yt_1200.png";
+                CACHED_VIDEOS.add(videoTag);
             }
-
-            usageByDay[date][videoTag].title =
-                res.data.type === "video" ? res.data.title : res.data.channelName || "Youtube";
-            usageByDay[date][videoTag].thumbnailUrl =
-                res.data.thumbnailUrl || "https://www.youtube.com/img/desktop/yt_1200.png";
-
+            usageByDay[date][videoTag].usage = oldUsage + pendingUsage;
+            updateBadge(usageByDay, date);
             await setToLocalCache({ usageByDay });
 
             pendingUsage = 0;

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -20,11 +20,10 @@ void (async () => {
     const CACHED_VIDEOS = new Set<string>();
     do {
         try {
+            if (pendingUsage === 0) continue;
+
             const videoTag = extractVideoTag(getCurrentTabUrl());
-            if (!videoTag) {
-                await delay(500);
-                continue;
-            }
+            if (!videoTag) continue;
 
             const date = utcDateKey(new Date());
             const usageByDay = await getUsageByDay();

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -32,6 +32,7 @@ void (async () => {
                 usage: 0,
                 title: undefined,
                 thumbnailUrl: undefined,
+                channelName: undefined,
             };
 
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -51,6 +52,7 @@ void (async () => {
                     res.data.type === "video" ? res.data.title : res.data.channelName || "Youtube";
                 usageByDay[date][videoTag].thumbnailUrl =
                     res.data.thumbnailUrl || "https://www.youtube.com/img/desktop/yt_1200.png";
+                usageByDay[date][videoTag].channelName = res.data.channelName;
                 CACHED_VIDEOS.add(videoTag);
             }
             usageByDay[date][videoTag].usage = oldUsage + pendingUsage;

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -2,7 +2,7 @@ import { setToLocalCache } from "@lib/cache";
 import { delay, extractVideoTag } from "@lib/utils";
 import { getUsageByDay, utcDateKey } from "@lib/analyticsUtils";
 import { sendMessageToBackground } from "@/runtime";
-import { updateBadge } from "./badge";
+import { updateBadge } from "@/badge";
 
 let pendingUsage: number = 0;
 const observer = new PerformanceObserver((list) => {

--- a/src/qualityMenuInjector.ts
+++ b/src/qualityMenuInjector.ts
@@ -1,7 +1,7 @@
 import "@styles/panel.css";
 import type { YoutubeData } from "@app-types/types";
-import { totalSizeVideoDisplay } from "./lib/formatting";
-import { waitForElement } from "./lib/dom";
+import { totalSizeVideoDisplay } from "@lib/formatting";
+import { waitForElement } from "@lib/dom";
 
 let settingsBtnEl: Element | undefined;
 let qualityBtnEl: Element | undefined;

--- a/src/resolution.ts
+++ b/src/resolution.ts
@@ -1,7 +1,7 @@
 import { showTwitchToast, showYoutubeToast } from "@pages/toaster";
 import type { KickData, TwitchData, YoutubeData } from "@app-types/types";
-import CONFIG from "./lib/constants";
-import { getFromSyncCache } from "./lib/cache";
+import CONFIG from "@lib/constants";
+import { getFromSyncCache } from "@lib/cache";
 
 /**
  * Get the current resolution of the video being played on thepage by observing the DOM for video element.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -11,8 +11,8 @@ type MessageResponseMap = {
     twitchLive: TwitchBackgroundResponse;
     kickLive: KickBackgroundResponse;
     kickVod: KickBackgroundResponse;
-    clearBadge: { success: boolean };
     setBadge: { success: boolean };
+    removeBadge: { success: boolean };
 };
 export async function sendMessageToBackground<T extends FrontEndMessage>(
     message: T,

--- a/src/styles/analytics.css
+++ b/src/styles/analytics.css
@@ -6,15 +6,14 @@
 }
 
 .analytics-header {
-    font-size: 14px;
-    font-weight: 700;
+    display: flex;
+    align-items: center;
+
     border-bottom: 1px solid #ffffff0f;
     color: #d8e7e5;
     background: #161819;
     padding: 14px 20px;
-    font-family: "JetBrains Mono", "SF Mono", "Fira Code", monospace;
-    text-transform: uppercase;
-    letter-spacing: 1.2px;
+    gap: 12px;
 }
 
 .analytics-body {
@@ -23,6 +22,19 @@
     background: #111212;
     flex-direction: column;
     flex: 1;
+}
+
+.analytics-header span {
+    font-size: 14px;
+    font-weight: 700;
+    font-family: "JetBrains Mono", "SF Mono", "Fira Code", monospace;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+}
+
+.analytics-icon {
+    width: 24px;
+    height: 24px;
 }
 
 .stats-row {

--- a/src/styles/analytics.css
+++ b/src/styles/analytics.css
@@ -96,7 +96,7 @@
     border: 1px solid #42282867;
     border-radius: 8px;
     background-color: #161819;
-    padding: 14px 20px 20px;
+    padding: 14px 20px 0px 20px;
 }
 .graph-header {
     display: flex;

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -76,17 +76,22 @@
     color: #ffffff;
 }
 
-.today-usage {
+.today-usage button {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background-color: rgba(255, 255, 255, 0.03);
     padding: 8px 12px;
     border-radius: 8px;
-    color: #a8a8b1;
-    font-size: 12px;
-    font-weight: 500;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    color: #a8a8b1;
+    font-weight: 500;
+    font-size: 12px;
+    width: 100%;
+}
+.today-usage button:hover {
+    background-color: rgba(255, 255, 255, 0.06);
+    cursor: pointer;
 }
 .today-usage-value {
     color: #ffebebe8;

--- a/src/styles/usageDetails.css
+++ b/src/styles/usageDetails.css
@@ -1,14 +1,9 @@
-html,
-body,
-#root {
-    height: 100%;
-}
-
 .usage-details {
     display: flex;
     flex-direction: column;
     height: 100%;
     width: 100%;
+    min-height: 100vh;
 }
 
 .usage-details-header {

--- a/src/styles/usageDetails.css
+++ b/src/styles/usageDetails.css
@@ -53,6 +53,7 @@ body,
 }
 
 .body-wrapper {
+    display: flex;
     padding: 32px;
     background: #0e1012;
     flex: 1;
@@ -84,6 +85,7 @@ body,
 }
 
 .usage-details-list {
+    flex: 1;
     border: 1px solid #ffffff0f;
     border-radius: 16px;
     background: #161819;

--- a/src/styles/usageDetails.css
+++ b/src/styles/usageDetails.css
@@ -140,6 +140,6 @@ tbody tr:hover {
     text-align: center;
     width: 60px;
 }
-.index {
+.usage-table td.index {
     text-align: center;
 }

--- a/src/styles/usageDetails.css
+++ b/src/styles/usageDetails.css
@@ -136,6 +136,29 @@ tbody tr:hover {
     overflow: hidden;
 }
 
+.video-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    overflow: hidden;
+    min-width: 0;
+}
+
+.video-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.video-channel {
+    font-size: 12px;
+    color: #8b8d93;
+    font-weight: 400;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 #header-index {
     text-align: center;
     width: 60px;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -102,8 +102,8 @@ export type FrontEndMessage =
     | TwitchLiveMessage
     | KickLiveMessage
     | KickVodMessage
-    | { type: "clearBadge" }
-    | { type: "setBadge" };
+    | { type: "removeBadge"; tabId: number }
+    | { type: "setBadge"; text: string };
 
 export type YoutubeMessage = {
     type: "youtubeVideo";

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -47,6 +47,7 @@ export type YoutubeVideoData = {
     id: string;
     isShorts?: boolean;
     thumbnailUrl: string | undefined;
+    channelName: string | undefined;
 };
 
 type YoutubeLiveData = {

--- a/src/types/uiTypes.ts
+++ b/src/types/uiTypes.ts
@@ -1,4 +1,4 @@
-import type { KickData, TwitchData, YoutubeData } from "./types";
+import type { KickData, TwitchData, YoutubeData } from "@app-types/types";
 
 export type PopupData =
     | {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Badge System Refactoring

- Replaced addBadge/clearBadge with setBadge(text, tabId?) and removeBadge(tabId?); setBadge applies a fixed badge background color.
- Badge lifecycle moved into tab logic: chrome.tabs.onUpdated shows the badge for YouTube pages (removes it otherwise) and chrome.tabs.onRemoved cleans per-tab URL tracking to avoid leaks.
- Centralized badge computation: updateBadge(usageByDay, date) uses getTotalUsageForDate and badgeFormatter to compute and format totals, sending a background message to set the badge.
- Background handlers no longer perform badge side-effects during YouTube response flows; runtime messages "setBadge" and "removeBadge" are routed to dedicated handlers.

## Analytics UI and Display Improvements

- Analytics header now includes an icon and the title “Usage Analytics for YouTube” with a flex-based layout.
- Labels clarified: “This Week” → “Last 7 Days”, “This Month” → “Last 30 Days”.
- Date ranges standardized across components using toDateString() and a " -> " separator.
- Video lists in Today / Week / Month / Lifetime views are sorted by descending usage and now render channelName when available.
- Chart scaling adjusted to compute megabytes using 1024 * 1024.

## Helper & Formatting Enhancements

- Added getTotalUsageForDate(usageByDay, date) to sum daily usage (returns 0 for missing dates).
- formatBytes now accepts an optional options object (e.g., round) forwarded to filesize.
- Introduced badgeFormatter(bytes) producing compact B/K/M/G strings (K/M use toFixed(0); G uses toFixed(1)).
- totalSizeVideoDisplay now delegates to filesize(...) for consistent formatting.

## Observer & Runtime Changes

- Observer: missing videoTag now continues immediately (no 10_000 ms delay). An in-memory CACHED_VIDEOS Set avoids redundant metadata fetches; metadata fetched once per videoTag is reused while usage continues to accumulate.
- Observer updates usageByDay and calls updateBadge(usageByDay, date) before persisting to cache so the badge reflects current totals.
- Runtime/message types updated: FrontEndMessage replaces clearBadge with removeBadge(tabId) and refines setBadge to include text; MessageResponseMap and sendMessageToBackground typings updated.
- Many imports migrated to path aliases (`@lib/*`, `@/runtime`, `@app-types/*`, etc.).

## UI/Styling & Popup Behavior

- Popup “YouTube Usage Today” value is now a clickable button that opens `#/today` in a new tab.
- CSS tweaks: analytics header layout and icon sizing, graph padding, popup button styles/hover, usage-details layout, and new video-info/title/channel truncation rules.

## Miscellaneous

- .gitignore updated to ignore *.tsbuildinfo.
- Types updated: YoutubeVideoData and UsageByVideo entries now include optional channelName.
- Minor JSDoc and import-path cleanups across several modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MohamedSayed0573/TubeSize_Extension/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->