### PR TITLE
fixed sorting

### DIFF
--- a/src/components/analytics/lifeTimeUsage.tsx
+++ b/src/components/analytics/lifeTimeUsage.tsx
@@ -45,6 +45,16 @@ export default function LifetimeUsage() {
         })();
     }, []);
 
+    const allVideos = Object.entries(lifeTimeUsage)
+        .flatMap(([date, videos]) => {
+            return Object.entries(videos).map(([videoTag, details]) => ({
+                videoTag,
+                date,
+                ...details,
+            }));
+        })
+        .sort((a, b) => b.usage - a.usage);
+
     let index = 0;
 
     return (
@@ -84,57 +94,57 @@ export default function LifetimeUsage() {
                                 </tr>
                             </thead>
                             <tbody>
-                                {Object.entries(lifeTimeUsage).map(([date, videos]) =>
-                                    Object.entries(videos)
-                                        .sort((a, b) => b[1].usage - a[1].usage)
-                                        .map(
-                                            ([
-                                                videoTag,
-                                                { usage, title, thumbnailUrl, channelName },
-                                            ]) => {
-                                                const url = getVideoUrl(videoTag);
+                                {allVideos.map(
+                                    ({
+                                        videoTag,
+                                        usage,
+                                        title,
+                                        thumbnailUrl,
+                                        date,
+                                        channelName,
+                                    }) => {
+                                        const url = getVideoUrl(videoTag);
 
-                                                const imageUrl =
-                                                    thumbnailUrl ||
-                                                    "https://placehold.co/213x120?text=Unknown&font=roboto";
+                                        const imageUrl =
+                                            thumbnailUrl ||
+                                            "https://placehold.co/213x120?text=Unknown&font=roboto";
 
-                                                const displayTitle = title || "Youtube";
+                                        const displayTitle = title || "Youtube";
 
-                                                return (
-                                                    <tr key={`${date}-${videoTag}`}>
-                                                        <td className="index">{index++ + 1}</td>
+                                        return (
+                                            <tr key={`${date}-${videoTag}`}>
+                                                <td className="index">{index++ + 1}</td>
 
-                                                        <td>
-                                                            <a
-                                                                className="video-title-cell"
-                                                                target="_blank"
-                                                                rel="noreferrer"
-                                                                href={url}
-                                                            >
-                                                                <img
-                                                                    className="video-thumbnail"
-                                                                    src={imageUrl}
-                                                                    alt="thumbnail"
-                                                                />
+                                                <td>
+                                                    <a
+                                                        className="video-title-cell"
+                                                        target="_blank"
+                                                        rel="noreferrer"
+                                                        href={url}
+                                                    >
+                                                        <img
+                                                            className="video-thumbnail"
+                                                            src={imageUrl}
+                                                            alt="thumbnail"
+                                                        />
 
-                                                                <div className="video-info">
-                                                                    <span className="video-title">
-                                                                        {displayTitle}
-                                                                    </span>
-                                                                    {channelName && (
-                                                                        <span className="video-channel">
-                                                                            {channelName}
-                                                                        </span>
-                                                                    )}
-                                                                </div>
-                                                            </a>
-                                                        </td>
+                                                        <div className="video-info">
+                                                            <span className="video-title">
+                                                                {displayTitle}
+                                                            </span>
+                                                            {channelName && (
+                                                                <span className="video-channel">
+                                                                    {channelName}
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                    </a>
+                                                </td>
 
-                                                        <td>{formatBytes(usage)}</td>
-                                                    </tr>
-                                                );
-                                            },
-                                        ),
+                                                <td>{formatBytes(usage)}</td>
+                                            </tr>
+                                        );
+                                    },
                                 )}
                             </tbody>
                         </table>

--- a/src/components/analytics/lifeTimeUsage.tsx
+++ b/src/components/analytics/lifeTimeUsage.tsx
@@ -1,12 +1,14 @@
 import {
     formatBytes,
     getNumVideosWatched,
+    getSortedVideoUsageRows,
     getUsageByDay,
     isEmptyUsageByDay,
     type UsageByDay,
 } from "@lib/analyticsUtils";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
+import VideoCard from "./videoCard";
 
 function getLifeTimeDateRange(usageByDay: UsageByDay) {
     const dates = Object.keys(usageByDay);
@@ -30,9 +32,6 @@ function getTotalUsage(lifeTimeUsage: UsageByDay) {
     }
     return total;
 }
-function getVideoUrl(videoTag: string) {
-    return `https://youtube.com/watch?v=${videoTag}`;
-}
 
 export default function LifetimeUsage() {
     const navigate = useNavigate();
@@ -45,16 +44,7 @@ export default function LifetimeUsage() {
         })();
     }, []);
 
-    const allVideos = Object.entries(lifeTimeUsage)
-        .flatMap(([date, videos]) => {
-            return Object.entries(videos).map(([videoTag, details]) => ({
-                videoTag,
-                date,
-                ...details,
-            }));
-        })
-        .sort((a, b) => b.usage - a.usage);
-
+    const allVideos = useMemo(() => getSortedVideoUsageRows(lifeTimeUsage), [lifeTimeUsage]);
     let index = 0;
 
     return (
@@ -94,58 +84,16 @@ export default function LifetimeUsage() {
                                 </tr>
                             </thead>
                             <tbody>
-                                {allVideos.map(
-                                    ({
-                                        videoTag,
-                                        usage,
-                                        title,
-                                        thumbnailUrl,
-                                        date,
-                                        channelName,
-                                    }) => {
-                                        const url = getVideoUrl(videoTag);
-
-                                        const imageUrl =
-                                            thumbnailUrl ||
-                                            "https://placehold.co/213x120?text=Unknown&font=roboto";
-
-                                        const displayTitle = title || "Youtube";
-
-                                        return (
-                                            <tr key={`${date}-${videoTag}`}>
-                                                <td className="index">{index++ + 1}</td>
-
-                                                <td>
-                                                    <a
-                                                        className="video-title-cell"
-                                                        target="_blank"
-                                                        rel="noreferrer"
-                                                        href={url}
-                                                    >
-                                                        <img
-                                                            className="video-thumbnail"
-                                                            src={imageUrl}
-                                                            alt="thumbnail"
-                                                        />
-
-                                                        <div className="video-info">
-                                                            <span className="video-title">
-                                                                {displayTitle}
-                                                            </span>
-                                                            {channelName && (
-                                                                <span className="video-channel">
-                                                                    {channelName}
-                                                                </span>
-                                                            )}
-                                                        </div>
-                                                    </a>
-                                                </td>
-
-                                                <td>{formatBytes(usage)}</td>
-                                            </tr>
-                                        );
-                                    },
-                                )}
+                                {allVideos.map((videoDetails) => {
+                                    index++;
+                                    return (
+                                        <VideoCard
+                                            key={`${videoDetails.date}-${videoDetails.videoTag}`}
+                                            videoDetails={videoDetails}
+                                            index={index}
+                                        />
+                                    );
+                                })}
                             </tbody>
                         </table>
                         {isEmptyUsageByDay(lifeTimeUsage) && (

--- a/src/components/analytics/monthUsage.tsx
+++ b/src/components/analytics/monthUsage.tsx
@@ -2,13 +2,15 @@ import {
     formatBytes,
     getLast30Days,
     getNumVideosWatched,
+    getSortedVideoUsageRows,
     getUsageByDay,
     isEmptyUsageByDay,
     utcDateKey,
     type UsageByDay,
 } from "@lib/analyticsUtils";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
+import VideoCard from "@components/analytics/videoCard";
 
 function getMonthTotalUsage(monthUsage: UsageByDay) {
     let total = 0;
@@ -40,10 +42,6 @@ function formatDate(month: Date[]) {
     return `${startDate.toDateString().split(" ").slice(1).join(" ")} -> ${endDate.toDateString().split(" ").slice(1).join(" ")}`;
 }
 
-function getVideoUrl(videoTag: string) {
-    return `https://youtube.com/watch?v=${videoTag}`;
-}
-
 export default function MonthUsage() {
     const navigate = useNavigate();
     const [monthUsage, setMonthUsage] = useState<UsageByDay>({});
@@ -56,16 +54,7 @@ export default function MonthUsage() {
         })();
     }, []);
 
-    const allVideos = Object.entries(monthUsage)
-        .flatMap(([date, videos]) => {
-            return Object.entries(videos).map(([videoTag, details]) => ({
-                videoTag,
-                date,
-                ...details,
-            }));
-        })
-        .sort((a, b) => b.usage - a.usage);
-
+    const allVideos = useMemo(() => getSortedVideoUsageRows(monthUsage), [monthUsage]);
     let index = 0;
 
     return (
@@ -105,58 +94,16 @@ export default function MonthUsage() {
                                 </tr>
                             </thead>
                             <tbody>
-                                {allVideos.map(
-                                    ({
-                                        channelName,
-                                        date,
-                                        thumbnailUrl,
-                                        title,
-                                        usage,
-                                        videoTag,
-                                    }) => {
-                                        const url = getVideoUrl(videoTag);
-
-                                        const imageUrl =
-                                            thumbnailUrl ||
-                                            "https://placehold.co/213x120?text=Unknown&font=roboto";
-
-                                        const displayTitle = title || "Youtube";
-
-                                        return (
-                                            <tr key={`${date}-${videoTag}`}>
-                                                <td className="index">{index++ + 1}</td>
-
-                                                <td>
-                                                    <a
-                                                        className="video-title-cell"
-                                                        target="_blank"
-                                                        rel="noreferrer"
-                                                        href={url}
-                                                    >
-                                                        <img
-                                                            className="video-thumbnail"
-                                                            src={imageUrl}
-                                                            alt="thumbnail"
-                                                        />
-
-                                                        <div className="video-info">
-                                                            <span className="video-title">
-                                                                {displayTitle}
-                                                            </span>
-                                                            {channelName && (
-                                                                <span className="video-channel">
-                                                                    {channelName}
-                                                                </span>
-                                                            )}
-                                                        </div>
-                                                    </a>
-                                                </td>
-
-                                                <td>{formatBytes(usage)}</td>
-                                            </tr>
-                                        );
-                                    },
-                                )}
+                                {allVideos.map((videoDetails) => {
+                                    index++;
+                                    return (
+                                        <VideoCard
+                                            key={`${videoDetails.date}-${videoDetails.videoTag}`}
+                                            videoDetails={videoDetails}
+                                            index={index}
+                                        />
+                                    );
+                                })}
                             </tbody>
                         </table>
                         {isEmptyUsageByDay(monthUsage) && (

--- a/src/components/analytics/monthUsage.tsx
+++ b/src/components/analytics/monthUsage.tsx
@@ -56,6 +56,16 @@ export default function MonthUsage() {
         })();
     }, []);
 
+    const allVideos = Object.entries(monthUsage)
+        .flatMap(([date, videos]) => {
+            return Object.entries(videos).map(([videoTag, details]) => ({
+                videoTag,
+                date,
+                ...details,
+            }));
+        })
+        .sort((a, b) => b.usage - a.usage);
+
     let index = 0;
 
     return (
@@ -95,57 +105,57 @@ export default function MonthUsage() {
                                 </tr>
                             </thead>
                             <tbody>
-                                {Object.entries(monthUsage).map(([date, videos]) =>
-                                    Object.entries(videos)
-                                        .sort((a, b) => b[1].usage - a[1].usage)
-                                        .map(
-                                            ([
-                                                videoTag,
-                                                { usage, title, thumbnailUrl, channelName },
-                                            ]) => {
-                                                const url = getVideoUrl(videoTag);
+                                {allVideos.map(
+                                    ({
+                                        channelName,
+                                        date,
+                                        thumbnailUrl,
+                                        title,
+                                        usage,
+                                        videoTag,
+                                    }) => {
+                                        const url = getVideoUrl(videoTag);
 
-                                                const imageUrl =
-                                                    thumbnailUrl ||
-                                                    "https://placehold.co/213x120?text=Unknown&font=roboto";
+                                        const imageUrl =
+                                            thumbnailUrl ||
+                                            "https://placehold.co/213x120?text=Unknown&font=roboto";
 
-                                                const displayTitle = title || "Youtube";
+                                        const displayTitle = title || "Youtube";
 
-                                                return (
-                                                    <tr key={`${date}-${videoTag}`}>
-                                                        <td className="index">{index++ + 1}</td>
+                                        return (
+                                            <tr key={`${date}-${videoTag}`}>
+                                                <td className="index">{index++ + 1}</td>
 
-                                                        <td>
-                                                            <a
-                                                                className="video-title-cell"
-                                                                target="_blank"
-                                                                rel="noreferrer"
-                                                                href={url}
-                                                            >
-                                                                <img
-                                                                    className="video-thumbnail"
-                                                                    src={imageUrl}
-                                                                    alt="thumbnail"
-                                                                />
+                                                <td>
+                                                    <a
+                                                        className="video-title-cell"
+                                                        target="_blank"
+                                                        rel="noreferrer"
+                                                        href={url}
+                                                    >
+                                                        <img
+                                                            className="video-thumbnail"
+                                                            src={imageUrl}
+                                                            alt="thumbnail"
+                                                        />
 
-                                                                <div className="video-info">
-                                                                    <span className="video-title">
-                                                                        {displayTitle}
-                                                                    </span>
-                                                                    {channelName && (
-                                                                        <span className="video-channel">
-                                                                            {channelName}
-                                                                        </span>
-                                                                    )}
-                                                                </div>
-                                                            </a>
-                                                        </td>
+                                                        <div className="video-info">
+                                                            <span className="video-title">
+                                                                {displayTitle}
+                                                            </span>
+                                                            {channelName && (
+                                                                <span className="video-channel">
+                                                                    {channelName}
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                    </a>
+                                                </td>
 
-                                                        <td>{formatBytes(usage)}</td>
-                                                    </tr>
-                                                );
-                                            },
-                                        ),
+                                                <td>{formatBytes(usage)}</td>
+                                            </tr>
+                                        );
+                                    },
                                 )}
                             </tbody>
                         </table>

--- a/src/components/analytics/videoCard.tsx
+++ b/src/components/analytics/videoCard.tsx
@@ -1,0 +1,59 @@
+import { formatBytes } from "@/lib/analyticsUtils";
+import { Link } from "react-router";
+
+function getVideoUrl(videoTag: string) {
+    return `https://youtube.com/watch?v=${videoTag}`;
+}
+
+type VideoDetails = {
+    usage: number;
+    title: string | undefined;
+    thumbnailUrl: string | undefined;
+    channelName: string | undefined;
+    videoTag: string;
+    date: string;
+};
+
+export default function VideoCard({
+    videoDetails,
+    index,
+}: {
+    videoDetails: VideoDetails;
+    index: number;
+}) {
+    const { date, videoTag, usage } = videoDetails;
+    const url = getVideoUrl(videoDetails.videoTag);
+
+    const imageUrl =
+        videoDetails.thumbnailUrl || "https://placehold.co/213x120?text=Unknown&font=roboto";
+
+    const displayTitle = videoDetails.title || "Youtube";
+
+    return (
+        <tr key={`${date}-${videoTag}`}>
+            <td className="index">{index}</td>
+
+            <td>
+                <a className="video-title-cell" target="_blank" rel="noreferrer" href={url}>
+                    <img className="video-thumbnail" src={imageUrl} alt="thumbnail" />
+
+                    <div className="video-info">
+                        <span className="video-title">{displayTitle}</span>
+                        {videoDetails.channelName && (
+                            <span className="video-channel">
+                                <a href={"https://www.youtube.com/@" + videoDetails.channelName}>
+                                    {videoDetails.channelName}
+                                </a>
+                            </span>
+                        )}
+                        <span className="date-cell">
+                            <Link to={`/analytics/${date}`}>{date}</Link>
+                        </span>
+                    </div>
+                </a>
+            </td>
+
+            <td>{formatBytes(usage)}</td>
+        </tr>
+    );
+}

--- a/src/components/analytics/weekUsage.tsx
+++ b/src/components/analytics/weekUsage.tsx
@@ -2,13 +2,15 @@ import {
     formatBytes,
     getLast7Days,
     getNumVideosWatched,
+    getSortedVideoUsageRows,
     getUsageByDay,
     isEmptyUsageByDay,
     utcDateKey,
     type UsageByDay,
 } from "@lib/analyticsUtils";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
+import VideoCard from "@components/analytics/videoCard";
 
 function getWeekTotalUsage(weekUsage: UsageByDay) {
     let total = 0;
@@ -40,10 +42,6 @@ function formatDate(week: Date[]) {
     return `${startDate.toDateString().split(" ").slice(1).join(" ")} -> ${endDate.toDateString().split(" ").slice(1).join(" ")}`;
 }
 
-function getVideoUrl(videoTag: string) {
-    return `https://youtube.com/watch?v=${videoTag}`;
-}
-
 export default function WeekUsage() {
     const navigate = useNavigate();
     const [weekUsage, setWeekUsage] = useState<UsageByDay>({});
@@ -56,16 +54,7 @@ export default function WeekUsage() {
         })();
     }, []);
 
-    const allVideos = Object.entries(weekUsage)
-        .flatMap(([date, videos]) => {
-            return Object.entries(videos).map(([videoTag, details]) => ({
-                videoTag,
-                date,
-                ...details,
-            }));
-        })
-        .sort((a, b) => b.usage - a.usage);
-
+    const allVideos = useMemo(() => getSortedVideoUsageRows(weekUsage), [weekUsage]);
     let index = 0;
 
     return (
@@ -105,58 +94,16 @@ export default function WeekUsage() {
                                 </tr>
                             </thead>
                             <tbody>
-                                {allVideos.map(
-                                    ({
-                                        date,
-                                        channelName,
-                                        thumbnailUrl,
-                                        title,
-                                        usage,
-                                        videoTag,
-                                    }) => {
-                                        const url = getVideoUrl(videoTag);
-
-                                        const imageUrl =
-                                            thumbnailUrl ||
-                                            "https://placehold.co/213x120?text=Unknown&font=roboto";
-
-                                        const displayTitle = title || "Youtube";
-
-                                        return (
-                                            <tr key={`${date}-${videoTag}`}>
-                                                <td className="index">{index++ + 1}</td>
-
-                                                <td>
-                                                    <a
-                                                        className="video-title-cell"
-                                                        target="_blank"
-                                                        rel="noreferrer"
-                                                        href={url}
-                                                    >
-                                                        <img
-                                                            className="video-thumbnail"
-                                                            src={imageUrl}
-                                                            alt="thumbnail"
-                                                        />
-
-                                                        <div className="video-info">
-                                                            <span className="video-title">
-                                                                {displayTitle}
-                                                            </span>
-                                                            {channelName && (
-                                                                <span className="video-channel">
-                                                                    {channelName}
-                                                                </span>
-                                                            )}
-                                                        </div>
-                                                    </a>
-                                                </td>
-
-                                                <td>{formatBytes(usage)}</td>
-                                            </tr>
-                                        );
-                                    },
-                                )}
+                                {allVideos.map((videoDetails) => {
+                                    index++;
+                                    return (
+                                        <VideoCard
+                                            key={`${videoDetails.date}-${videoDetails.videoTag}`}
+                                            videoDetails={videoDetails}
+                                            index={index}
+                                        />
+                                    );
+                                })}
                             </tbody>
                         </table>
                         {isEmptyUsageByDay(weekUsage) && (

--- a/src/components/analytics/weekUsage.tsx
+++ b/src/components/analytics/weekUsage.tsx
@@ -56,6 +56,16 @@ export default function WeekUsage() {
         })();
     }, []);
 
+    const allVideos = Object.entries(weekUsage)
+        .flatMap(([date, videos]) => {
+            return Object.entries(videos).map(([videoTag, details]) => ({
+                videoTag,
+                date,
+                ...details,
+            }));
+        })
+        .sort((a, b) => b.usage - a.usage);
+
     let index = 0;
 
     return (
@@ -95,57 +105,57 @@ export default function WeekUsage() {
                                 </tr>
                             </thead>
                             <tbody>
-                                {Object.entries(weekUsage).map(([date, videos]) =>
-                                    Object.entries(videos)
-                                        .sort((a, b) => b[1].usage - a[1].usage)
-                                        .map(
-                                            ([
-                                                videoTag,
-                                                { usage, title, thumbnailUrl, channelName },
-                                            ]) => {
-                                                const url = getVideoUrl(videoTag);
+                                {allVideos.map(
+                                    ({
+                                        date,
+                                        channelName,
+                                        thumbnailUrl,
+                                        title,
+                                        usage,
+                                        videoTag,
+                                    }) => {
+                                        const url = getVideoUrl(videoTag);
 
-                                                const imageUrl =
-                                                    thumbnailUrl ||
-                                                    "https://placehold.co/213x120?text=Unknown&font=roboto";
+                                        const imageUrl =
+                                            thumbnailUrl ||
+                                            "https://placehold.co/213x120?text=Unknown&font=roboto";
 
-                                                const displayTitle = title || "Youtube";
+                                        const displayTitle = title || "Youtube";
 
-                                                return (
-                                                    <tr key={`${date}-${videoTag}`}>
-                                                        <td className="index">{index++ + 1}</td>
+                                        return (
+                                            <tr key={`${date}-${videoTag}`}>
+                                                <td className="index">{index++ + 1}</td>
 
-                                                        <td>
-                                                            <a
-                                                                className="video-title-cell"
-                                                                target="_blank"
-                                                                rel="noreferrer"
-                                                                href={url}
-                                                            >
-                                                                <img
-                                                                    className="video-thumbnail"
-                                                                    src={imageUrl}
-                                                                    alt="thumbnail"
-                                                                />
+                                                <td>
+                                                    <a
+                                                        className="video-title-cell"
+                                                        target="_blank"
+                                                        rel="noreferrer"
+                                                        href={url}
+                                                    >
+                                                        <img
+                                                            className="video-thumbnail"
+                                                            src={imageUrl}
+                                                            alt="thumbnail"
+                                                        />
 
-                                                                <div className="video-info">
-                                                                    <span className="video-title">
-                                                                        {displayTitle}
-                                                                    </span>
-                                                                    {channelName && (
-                                                                        <span className="video-channel">
-                                                                            {channelName}
-                                                                        </span>
-                                                                    )}
-                                                                </div>
-                                                            </a>
-                                                        </td>
+                                                        <div className="video-info">
+                                                            <span className="video-title">
+                                                                {displayTitle}
+                                                            </span>
+                                                            {channelName && (
+                                                                <span className="video-channel">
+                                                                    {channelName}
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                    </a>
+                                                </td>
 
-                                                        <td>{formatBytes(usage)}</td>
-                                                    </tr>
-                                                );
-                                            },
-                                        ),
+                                                <td>{formatBytes(usage)}</td>
+                                            </tr>
+                                        );
+                                    },
                                 )}
                             </tbody>
                         </table>

--- a/src/lib/analyticsUtils.ts
+++ b/src/lib/analyticsUtils.ts
@@ -88,3 +88,15 @@ export function getTotalUsageForDate(usageByDay: UsageByDay, date: string) {
     }
     return total;
 }
+
+export function getSortedVideoUsageRows(lifeTimeUsage: UsageByDay) {
+    return Object.entries(lifeTimeUsage)
+        .flatMap(([date, videos]) => {
+            return Object.entries(videos).map(([videoTag, details]) => ({
+                videoTag,
+                date,
+                ...details,
+            }));
+        })
+        .sort((a, b) => b.usage - a.usage);
+}

--- a/src/styles/usageDetails.css
+++ b/src/styles/usageDetails.css
@@ -159,6 +159,30 @@ tbody tr:hover {
     white-space: nowrap;
 }
 
+.video-channel a {
+    color: #8b8d93;
+    text-decoration: none;
+}
+
+.video-channel a:hover,
+.date-cell a:hover {
+    text-decoration: underline;
+}
+
+.date-cell {
+    font-size: 12px;
+    color: #b4b8c2;
+    font-weight: 400;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.date-cell a {
+    color: #b4b8c2;
+    text-decoration: none;
+}
+
 #header-index {
     text-align: center;
     width: 60px;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Refactor: apply global sorting across analytics views by flattening per-day usage into a single sorted list
  - Added helper: getSortedVideoUsageRows(UsageByDay) in src/lib/analyticsUtils.ts to produce a flat, usage-descending list of video rows (videoTag, date, usage, title, thumbnailUrl, channelName)
- Components updated to consume pre-sorted rows
  - src/components/analytics/lifeTimeUsage.tsx
    - Use getSortedVideoUsageRows(lifeTimeUsage) (memoized) and map to VideoCard instead of nested per-day iteration and per-day sorting
    - Preserve totals and video count; no public API changes
  - src/components/analytics/monthUsage.tsx
    - Compute month subset (last 30 days), then flatten & sort via getSortedVideoUsageRows(monthUsage) and render with VideoCard
    - Removes inline URL/thumbnail/title logic and nested Object.entries() iteration
  - src/components/analytics/weekUsage.tsx
    - Compute week subset (last 7 days), then flatten & sort via getSortedVideoUsageRows(weekUsage) and render with VideoCard
    - Removes previous per-day sorting and inline row markup
- New UI row component
  - src/components/analytics/videoCard.tsx
    - New default-exported VideoCard component that renders a table row (<tr>) for a video row
    - Builds YouTube URL from videoTag, falls back to placeholder thumbnail and default title, conditionally links channel, links date to /analytics/{date}, and shows formatted usage
- Styles
  - src/styles/usageDetails.css
    - Added styling for .video-channel, .date-cell, and related anchor hover behaviors to match the new VideoCard markup
- Impact
  - Consistent, global sorting of videos by data usage across lifetime, month, and week views
  - Reduced duplication and simpler rendering logic by centralizing per-row rendering in VideoCard
  - No exported/public API signature changes to existing components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MohamedSayed0573/TubeSize_Extension/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->