### PR TITLE
Refactoring useEffects and useStates to TanStack Query

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import unicorn from "eslint-plugin-unicorn";
 import promises from "eslint-plugin-promise";
 import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
+import pluginQuery from "@tanstack/eslint-plugin-query";
 
 export default defineConfig([
     globalIgnores(["dist", "coverage"]),
@@ -19,8 +20,9 @@ export default defineConfig([
             react.configs.flat["jsx-runtime"],
             reactHooks.configs.flat.recommended,
             reactRefresh.configs.vite,
-            unicorn.configs["flat/recommended"],
+            unicorn.configs["recommended"],
             promises.configs["flat/recommended"],
+            pluginQuery.configs["flat/recommended"],
         ],
         languageOptions: {
             ecmaVersion: "latest",
@@ -60,6 +62,7 @@ export default defineConfig([
             "@typescript-eslint/no-unnecessary-type-assertion": "off",
             "unicorn/name-replacements": "off",
             "unicorn/no-computed-property-existence-check": "off",
+            "unicorn/no-null": "off",
         },
     },
     {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "react-dom": "^19.2.7",
         "react-router": "^8.2.0",
         "recharts": "^3.9.1",
+        "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.3",
         "zod": "^4.4.3"
     },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "dependencies": {
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@tailwindcss/vite": "^4.3.3",
+        "@tanstack/react-query": "^5.101.4",
         "clsx": "^2.1.1",
         "filesize": "^11.0.22",
         "humanize-duration": "^3.34.0",
@@ -56,6 +57,7 @@
     "devDependencies": {
         "@crxjs/vite-plugin": "^2.7.1",
         "@eslint/js": "^10.0.1",
+        "@tanstack/eslint-plugin-query": "^5.101.4",
         "@types/chrome": "^0.2.2",
         "@types/humanize-duration": "^3.27.4",
         "@types/jest": "^30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       recharts:
         specifier: ^3.9.1
         version: 3.9.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.8)(react@19.2.7)(redux@5.0.1)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -3327,6 +3330,9 @@ packages:
   synckit@0.11.13:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
@@ -7141,6 +7147,8 @@ snapshots:
   synckit@0.11.13:
     dependencies:
       '@pkgr/core': 0.3.6
+
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,7 +128,7 @@ importers:
         version: 3.9.6
       prettier-plugin-tailwindcss:
         specifier: ^0.8.1
-        version: 0.8.1(prettier@3.9.6)
+        version: 0.8.1(@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.9.6))(prettier@3.9.6)
       ts-jest:
         specifier: ^29.4.11
         version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@26.1.1))(typescript@6.0.3)
@@ -1005,6 +1005,25 @@ packages:
     resolution: {integrity: sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@trivago/prettier-plugin-sort-imports@6.0.2':
+    resolution: {integrity: sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@vue/compiler-sfc': 3.x
+      prettier: 2.x - 3.x
+      prettier-plugin-ember-template-tag: '>= 2.0.0'
+      prettier-plugin-svelte: 3.x
+      svelte: 4.x || 5.x
+    peerDependenciesMeta:
+      '@vue/compiler-sfc':
+        optional: true
+      prettier-plugin-ember-template-tag:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+      svelte:
+        optional: true
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -2341,6 +2360,9 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  javascript-natural-sort@0.7.1:
+    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
+
   jest-changed-files@30.4.1:
     resolution: {integrity: sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2635,6 +2657,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
@@ -2847,9 +2872,15 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -4489,6 +4520,21 @@ snapshots:
       '@tanstack/query-core': 5.101.4
       react: 19.2.7
 
+  '@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.9.6)':
+    dependencies:
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      javascript-natural-sort: 0.7.1
+      lodash-es: 4.18.1
+      minimatch: 9.0.9
+      parse-imports-exports: 0.2.4
+      prettier: 3.9.6
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -5957,6 +6003,9 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  javascript-natural-sort@0.7.1:
+    optional: true
+
   jest-changed-files@30.4.1:
     dependencies:
       execa: 5.1.1
@@ -6423,6 +6472,9 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1:
+    optional: true
+
   lodash.memoize@4.1.2: {}
 
   log-update@6.1.0:
@@ -6675,12 +6727,20 @@ snapshots:
 
   pako@1.0.11: {}
 
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
+    optional: true
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-statements@1.0.11:
+    optional: true
 
   path-exists@4.0.0: {}
 
@@ -6723,9 +6783,11 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.8.1(prettier@3.9.6):
+  prettier-plugin-tailwindcss@0.8.1(@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.9.6))(prettier@3.9.6):
     dependencies:
       prettier: 3.9.6
+    optionalDependencies:
+      '@trivago/prettier-plugin-sort-imports': 6.0.2(prettier@3.9.6)
 
   prettier@3.9.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@tanstack/react-query':
+        specifier: ^5.101.4
+        version: 5.101.4(react@19.2.7)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -51,6 +54,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.7.0(jiti@2.7.0))
+      '@tanstack/eslint-plugin-query':
+        specifier: ^5.101.4
+        version: 5.101.4(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
       '@types/chrome':
         specifier: ^0.2.2
         version: 0.2.2
@@ -979,6 +985,23 @@ packages:
     resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/eslint-plugin-query@5.101.4':
+    resolution: {integrity: sha512-jqAZJWXGd5PthJYH9wmC2O5Ry5xAN2/7zxi9qcANQ+Xix8V5JkqNRjZ8Fh+rYzqzVYGiHqbrHekt+uh38OZVpw==}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ^5.4.0 || ^6.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@tanstack/query-core@5.101.4':
+    resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
+
+  '@tanstack/react-query@5.101.4':
+    resolution: {integrity: sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -4443,6 +4466,22 @@ snapshots:
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
       vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0)
+
+  '@tanstack/eslint-plugin-query@5.101.4(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.7.0(jiti@2.7.0)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/query-core@5.101.4': {}
+
+  '@tanstack/react-query@5.101.4(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.4
+      react: 19.2.7
 
   '@tybys/wasm-util@0.10.3':
     dependencies:

--- a/src/background.ts
+++ b/src/background.ts
@@ -196,6 +196,7 @@ function handleSetBadge(
     return sendResponse({ success: true });
 }
 
+// Show the badge if the tab is a YouTube page
 const lastUrlByTab = new Map<number, string>();
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (changeInfo.status !== "complete") return;
@@ -215,6 +216,8 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 
 async function showBadge(tabId: number) {
     const usageByDay = await getUsageByDay();
+    if (!usageByDay) return;
+
     const total = getUsageNumber(getTodayUsage(usageByDay));
 
     setBadge(badgeFormatter(total), tabId);

--- a/src/background.ts
+++ b/src/background.ts
@@ -197,26 +197,21 @@ function handleSetBadge(
 }
 
 // Show the badge if the tab is a YouTube page
-const lastUrlByTab = new Map<number, string>();
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    if (changeInfo.status !== "complete") return;
-    if (!tab.url || tab.url === lastUrlByTab.get(tabId)) return;
-    lastUrlByTab.set(tabId, tab.url);
+    if (changeInfo.status !== "complete" || !tab.url) return;
     if (isYoutubePage(tab.url)) {
-        void showBadge(tabId);
+        void updateUsageBadge(tabId);
     } else {
         removeBadge(tabId);
     }
 });
 
-// Clean up map entries when a tab is closed to avoid memory leaks
-chrome.tabs.onRemoved.addListener((tabId) => {
-    lastUrlByTab.delete(tabId);
-});
-
-async function showBadge(tabId: number) {
+async function updateUsageBadge(tabId: number) {
     const usageByDay = await getUsageByDay();
-    if (!usageByDay) return;
+    if (!usageByDay) {
+        removeBadge(tabId);
+        return;
+    }
 
     const total = getUsageNumber(getTodayUsage(usageByDay));
 

--- a/src/hooks/useCurrentQuality.ts
+++ b/src/hooks/useCurrentQuality.ts
@@ -1,31 +1,22 @@
-import { delay } from "@lib/utils";
 import { sendMessageToContentScript } from "@/runtime";
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
-export default function useCurrentQuality(tabId?: number, tabUrl?: string) {
-    const [currentQuality, setCurrentQuality] = useState<number | undefined>();
+export default function useCurrentQuality(tabId: number | undefined) {
+    const query = useQuery({
+        queryKey: ["current-quality", tabId],
+        queryFn: async () => {
+            const quality = await sendMessageToContentScript(tabId!, {
+                type: "getCurrentResolution",
+            });
 
-    useEffect(() => {
-        void (async () => {
-            try {
-                if (!tabId) return;
+            return { quality };
+        },
+        enabled: !!tabId,
+    });
 
-                for (let attempt = 0; attempt < 5; attempt++) {
-                    const quality = await sendMessageToContentScript(tabId, {
-                        type: "getCurrentResolution",
-                    });
-
-                    if (typeof quality === "number") {
-                        setCurrentQuality(quality);
-                        return;
-                    }
-
-                    await delay(500);
-                }
-            } catch (err) {
-                console.error("Failed to get current quality:", err);
-            }
-        })();
-    }, [tabId, tabUrl]);
-    return { currentQuality };
+    return {
+        currentQuality: query.data,
+        isError: query.isError,
+        isPending: query.isPending,
+    };
 }

--- a/src/hooks/useCurrentQuality.ts
+++ b/src/hooks/useCurrentQuality.ts
@@ -9,14 +9,16 @@ export default function useCurrentQuality(tabId: number | undefined) {
                 type: "getCurrentResolution",
             });
 
+            if (!quality) throw new Error("Couldn't get the current quality.");
+
             return { quality };
         },
         enabled: !!tabId,
+        retry: 5,
+        retryDelay: 500,
     });
 
     return {
         currentQuality: query.data,
-        isError: query.isError,
-        isPending: query.isPending,
     };
 }

--- a/src/hooks/useKickData.ts
+++ b/src/hooks/useKickData.ts
@@ -1,42 +1,29 @@
-import { isKickStream, isKickVod } from "@/lib/utils";
 import { sendMessageToContentScript } from "@/runtime";
-import type { KickData } from "@/types/types";
-import { useEffect, useState } from "react";
+import { isKickStream, isKickVod } from "@lib/utils";
+import { useQuery } from "@tanstack/react-query";
 
 export function useKickData(tabUrl: string, tabId: number) {
-    const [data, setData] = useState<KickData>();
-    const [error, setError] = useState<Error>();
-    const [message, setMessage] = useState<string>();
-    const [isLoading, setIsLoading] = useState(true);
-    const [createdAt, setCreatedAt] = useState<string | undefined>();
-
-    useEffect(() => {
-        const getKickData = async () => {
-            try {
-                if (!tabId) return;
-                if (!isKickStream(tabUrl) && !isKickVod(tabUrl)) {
-                    setMessage("Open a Kick stream");
-                    return;
-                }
-
-                const response = await sendMessageToContentScript(tabId, {
-                    type: "getKick",
-                    isFromPopup: true,
-                });
-                if (!response?.success) {
-                    throw new Error(response?.message || "Failed to retrieve Kick data");
-                }
-                setData(response.data);
-                setCreatedAt(response.createdAt);
-            } catch (err) {
-                setError(err instanceof Error ? err : new Error(String(err)));
-            } finally {
-                setIsLoading(false);
+    const isKickRelated = !!isKickStream(tabUrl) && !isKickVod(tabUrl);
+    const query = useQuery({
+        queryKey: [tabUrl, tabId],
+        queryFn: async () => {
+            const response = await sendMessageToContentScript(tabId, {
+                type: "getKick",
+                isFromPopup: true,
+            });
+            if (!response?.success) {
+                throw new Error(response?.message || "Failed to retrieve Kick data");
             }
-        };
+            return {
+                data: response.data,
+                createdAt: response.createdAt,
+            };
+        },
+        enabled: isKickRelated,
+    });
 
-        void getKickData();
-    }, [tabId, tabUrl]);
-
-    return { data, error, message, isLoading, createdAt };
+    return {
+        query,
+        isKickRelated,
+    };
 }

--- a/src/hooks/useKickData.ts
+++ b/src/hooks/useKickData.ts
@@ -3,9 +3,9 @@ import { isKickStream, isKickVod } from "@lib/utils";
 import { useQuery } from "@tanstack/react-query";
 
 export function useKickData(tabUrl: string, tabId: number) {
-    const isKickRelated = !!isKickStream(tabUrl) && !isKickVod(tabUrl);
+    const isKickRelated = isKickStream(tabUrl) || isKickVod(tabUrl);
     const query = useQuery({
-        queryKey: [tabUrl, tabId],
+        queryKey: ["kick", tabUrl, tabId],
         queryFn: async () => {
             const response = await sendMessageToContentScript(tabId, {
                 type: "getKick",

--- a/src/hooks/useOptions.ts
+++ b/src/hooks/useOptions.ts
@@ -1,4 +1,4 @@
-import { getAllFromSyncCache, setToSyncCache } from "@lib/cache";
+import { clearLocalCache, getAllFromSyncCache, setToSyncCache } from "@lib/cache";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 export default function useOptions() {
@@ -8,7 +8,7 @@ export default function useOptions() {
         queryFn: async () => (await getAllFromSyncCache()) ?? {},
     });
 
-    const mutation = useMutation({
+    const updateOptionsMutation = useMutation({
         mutationFn: setToSyncCache,
 
         onSuccess: async () => {
@@ -16,10 +16,13 @@ export default function useOptions() {
         },
     });
 
+    const clearCacheMutation = useMutation({
+        mutationFn: clearLocalCache,
+    });
+
     return {
         query,
-        updateOptions: mutation.mutate,
-        updateIsPending: mutation.isPending,
-        updateIsError: mutation.isError,
+        updateOptionsMutation,
+        clearCacheMutation,
     };
 }

--- a/src/hooks/useOptions.ts
+++ b/src/hooks/useOptions.ts
@@ -18,6 +18,12 @@ export default function useOptions() {
 
     const clearCacheMutation = useMutation({
         mutationFn: clearLocalCache,
+
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: ["youtube"] });
+            await queryClient.invalidateQueries({ queryKey: ["twitch"] });
+            await queryClient.invalidateQueries({ queryKey: ["kick"] });
+        },
     });
 
     return {

--- a/src/hooks/useOptions.ts
+++ b/src/hooks/useOptions.ts
@@ -1,22 +1,25 @@
-import { getAllFromSyncCache } from "@lib/cache";
-import { useEffect, useState } from "react";
-import type { OptionsMap } from "@app-types/types";
+import { getAllFromSyncCache, setToSyncCache } from "@lib/cache";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 export default function useOptions() {
-    const [optionsState, setOptionsState] = useState<OptionsMap>({});
-    const [error, setError] = useState<Error | undefined>();
+    const queryClient = useQueryClient();
+    const query = useQuery({
+        queryKey: ["options"],
+        queryFn: async () => (await getAllFromSyncCache()) ?? {},
+    });
 
-    useEffect(() => {
-        void (async () => {
-            try {
-                const options = await getAllFromSyncCache();
-                setOptionsState(options);
-            } catch (err) {
-                console.error("Failed to load options from cache:", err);
-                setError(err as Error);
-            }
-        })();
-    }, []);
+    const mutation = useMutation({
+        mutationFn: setToSyncCache,
 
-    return { optionsState, setOptionsState, error };
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: ["options"] });
+        },
+    });
+
+    return {
+        query,
+        updateOptions: mutation.mutate,
+        updateIsPending: mutation.isPending,
+        updateIsError: mutation.isError,
+    };
 }

--- a/src/hooks/useTab.ts
+++ b/src/hooks/useTab.ts
@@ -1,26 +1,15 @@
 import { getTab } from "@/runtime";
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 export default function useTab() {
-    const [tabId, setTabId] = useState<number | undefined>();
-    const [tabUrl, setTabUrl] = useState<string | undefined>();
-    const [error, setError] = useState<Error | undefined>();
-    const [isLoading, setIsLoading] = useState(true);
-
-    useEffect(() => {
-        void (async () => {
-            try {
-                const activeTab = await getTab();
-                setTabId(activeTab?.id);
-                setTabUrl(activeTab?.url);
-            } catch (err) {
-                console.error("Failed to get active tab:", err);
-                setError(new Error("Failed to get active tab"));
-            } finally {
-                setIsLoading(false);
-            }
-        })();
-    }, []);
-
-    return { tabId, tabUrl, error, isLoading };
+    return useQuery({
+        queryKey: ["tab"],
+        queryFn: async () => {
+            const activeTab = await getTab();
+            return {
+                tabId: activeTab?.id,
+                tabUrl: activeTab?.url,
+            };
+        },
+    });
 }

--- a/src/hooks/useTwitchData.ts
+++ b/src/hooks/useTwitchData.ts
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 export function useTwitchData(tabUrl: string) {
     const isTwitchRelated = isTwitchPage(tabUrl);
     const query = useQuery({
-        queryKey: [tabUrl],
+        queryKey: ["twitch", tabUrl],
         queryFn: async () => {
             if (isTwitchVod(tabUrl)) {
                 const vodId = extractTwitchVodId(tabUrl);

--- a/src/hooks/useTwitchData.ts
+++ b/src/hooks/useTwitchData.ts
@@ -1,57 +1,51 @@
-import { extractChannelName, extractTwitchVodId, isTwitchVod } from "@/lib/utils";
+import { extractChannelName, extractTwitchVodId, isTwitchPage, isTwitchVod } from "@/lib/utils";
 import { sendMessageToBackground } from "@/runtime";
-import type { TwitchData } from "@/types/types";
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 export function useTwitchData(tabUrl: string) {
-    const [data, setData] = useState<TwitchData>();
-    const [error, setError] = useState<Error>();
-    const [message, setMessage] = useState<string>();
-    const [isLoading, setIsLoading] = useState(true);
-    const [createdAt, setCreatedAt] = useState<string | undefined>();
-
-    useEffect(() => {
-        const getTwitchData = async () => {
-            try {
-                if (isTwitchVod(tabUrl)) {
-                    const vodId = extractTwitchVodId(tabUrl);
-                    if (!vodId) {
-                        setMessage("Open a Twitch stream or VOD");
-                        return;
-                    }
-
-                    const response = await sendMessageToBackground({
-                        type: "twitchVod",
-                        vodId: vodId,
-                    });
-                    if (!response.success) throw new Error(response.message);
-
-                    setData(response.data);
-                    setCreatedAt(response.createdAt);
-                } else {
-                    const channelName = extractChannelName(tabUrl);
-                    if (!channelName) {
-                        setMessage("Open a Twitch stream");
-                        return;
-                    }
-
-                    const response = await sendMessageToBackground({
-                        type: "twitchLive",
-                        channelName: channelName,
-                        isFromPopup: true,
-                    });
-                    if (!response.success) throw new Error(response.message);
-                    setData(response.data);
+    const isTwitchRelated = isTwitchPage(tabUrl);
+    const query = useQuery({
+        queryKey: [tabUrl],
+        queryFn: async () => {
+            if (isTwitchVod(tabUrl)) {
+                const vodId = extractTwitchVodId(tabUrl);
+                if (!vodId) {
+                    throw new Error("Open a Twitch stream or VOD");
                 }
-            } catch (err) {
-                setError(err instanceof Error ? err : new Error(String(err)));
-            } finally {
-                setIsLoading(false);
+
+                const response = await sendMessageToBackground({
+                    type: "twitchVod",
+                    vodId: vodId,
+                });
+                if (!response.success) throw new Error(response.message);
+
+                return {
+                    data: response.data,
+                    createdAt: response.createdAt,
+                };
             }
-        };
+            const channelName = extractChannelName(tabUrl);
+            if (!channelName) {
+                throw new Error("Open a Twitch stream");
+            }
 
-        void getTwitchData();
-    }, [tabUrl]);
+            const response = await sendMessageToBackground({
+                type: "twitchLive",
+                channelName: channelName,
+                isFromPopup: true,
+            });
+            if (!response.success) throw new Error(response.message);
 
-    return { data, error, message, isLoading, createdAt };
+            return {
+                data: response.data,
+                createdAt: undefined,
+            };
+        },
+        enabled: isTwitchRelated,
+    });
+
+    return {
+        query,
+        isTwitchRelated,
+    };
 }

--- a/src/hooks/useUsage.ts
+++ b/src/hooks/useUsage.ts
@@ -1,19 +1,25 @@
 import { removeFromLocalCache } from "@/lib/cache";
 import { getUsageByDay } from "@lib/analyticsUtils";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 async function clearAllUsageData() {
     await removeFromLocalCache("usageByDay");
 }
 
 export default function useUsage() {
+    const queryClient = useQueryClient();
+
     const query = useQuery({
         queryKey: ["usage"],
-        queryFn: getUsageByDay,
+        queryFn: async () => (await getUsageByDay()) ?? null,
     });
 
-    const mutation = useMutation({
+    const clearUsageMutation = useMutation({
         mutationFn: clearAllUsageData,
+
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: ["usage"] });
+        },
     });
 
     /*
@@ -22,9 +28,6 @@ export default function useUsage() {
     */
     return {
         query,
-        clearUsage: mutation.mutate,
-        isClearing: mutation.isPending,
-        isClearingError: mutation.isError,
-        isClearingSuccess: mutation.isSuccess,
+        clearUsageMutation,
     };
 }

--- a/src/hooks/useUsage.ts
+++ b/src/hooks/useUsage.ts
@@ -1,25 +1,30 @@
-import { getUsageByDay, type UsageByDay } from "@/lib/analyticsUtils";
-import { useEffect, useState } from "react";
+import { removeFromLocalCache } from "@/lib/cache";
+import { getUsageByDay } from "@lib/analyticsUtils";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+async function clearAllUsageData() {
+    await removeFromLocalCache("usageByDay");
+}
 
 export default function useUsage() {
-    const [isLoading, setIsLoading] = useState(true);
-    const [usage, setUsage] = useState<UsageByDay>({});
-    const [error, setError] = useState<Error>();
-    useEffect(() => {
-        const fetchUsage = async () => {
-            try {
-                const usageByDay = await getUsageByDay();
-                setUsage(usageByDay);
-            } catch (err) {
-                console.error("Failed to load usage data", err);
-                setError(err instanceof Error ? err : new Error(String(err)));
-            } finally {
-                setIsLoading(false);
-            }
-        };
+    const query = useQuery({
+        queryKey: ["usage"],
+        queryFn: getUsageByDay,
+    });
 
-        void fetchUsage();
-    }, []);
+    const mutation = useMutation({
+        mutationFn: clearAllUsageData,
+    });
 
-    return { usage, setUsage, error, isLoading };
+    /*
+        I'm returning query itself here because I've faced issues with TS type narrowing when I returned specific properties.
+        Specifically, TS couldn't realize usage is not possibly undefined after checking againt isPending and isError.
+    */
+    return {
+        query,
+        clearUsage: mutation.mutate,
+        isClearing: mutation.isPending,
+        isClearingError: mutation.isError,
+        isClearingSuccess: mutation.isSuccess,
+    };
 }

--- a/src/hooks/useYoutubeData.ts
+++ b/src/hooks/useYoutubeData.ts
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 export function useYoutubeData(tabUrl: string, tabId: number) {
     const isYoutubeVideo = isYoutubePage(tabUrl) && !!extractVideoTag(tabUrl);
     const query = useQuery({
-        queryKey: [tabUrl, tabId],
+        queryKey: ["youtube", tabUrl, tabId],
         queryFn: async () => {
             const videoTag = extractVideoTag(tabUrl)!;
 

--- a/src/hooks/useYoutubeData.ts
+++ b/src/hooks/useYoutubeData.ts
@@ -1,54 +1,42 @@
-import { extractVideoTag, isShortsVideo } from "@/lib/utils";
+import { extractVideoTag, isShortsVideo, isYoutubePage } from "@/lib/utils";
 import { sendMessageToBackground } from "@/runtime";
-import type { YoutubeData } from "@/types/types";
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 export function useYoutubeData(tabUrl: string, tabId: number) {
-    const [message, setMessage] = useState<string>();
-    const [error, setError] = useState<Error>();
-    const [data, setData] = useState<YoutubeData>();
-    const [createdAt, setCreatedAt] = useState<string | undefined>();
-    const [isLoading, setIsLoading] = useState(true);
+    const isYoutubeVideo = isYoutubePage(tabUrl) && !!extractVideoTag(tabUrl);
+    const query = useQuery({
+        queryKey: [tabUrl, tabId],
+        queryFn: async () => {
+            const videoTag = extractVideoTag(tabUrl)!;
 
-    useEffect(() => {
-        const getYoutubeData = async () => {
-            try {
-                if (!tabUrl || !tabId) return;
-                const videoTag = extractVideoTag(tabUrl);
-                if (!videoTag) {
-                    setMessage("Open a Youtube video");
-                    return;
-                }
+            const response = await sendMessageToBackground({
+                type: "youtubeVideo",
+                videoTag,
+                tabId,
+            });
 
-                const response = await sendMessageToBackground({
-                    type: "youtubeVideo",
-                    videoTag,
-                    tabId,
-                });
-
-                if (!response.success) {
-                    throw new Error(response.message);
-                }
-
-                if (response.data.formats.length === 0) {
-                    throw new Error("No video formats found for this video");
-                }
-
-                if (response.data.type === "video" && isShortsVideo(tabUrl)) {
-                    response.data.isShorts = true;
-                }
-
-                setData(response.data);
-                setCreatedAt(response.createdAt);
-            } catch (err) {
-                setError(err instanceof Error ? err : new Error(String(err)));
-            } finally {
-                setIsLoading(false);
+            if (!response.success) {
+                throw new Error(response.message);
             }
-        };
 
-        void getYoutubeData();
-    }, [tabId, tabUrl]);
+            if (response.data.formats.length === 0) {
+                throw new Error("No video formats found for this video");
+            }
 
-    return { message, data, createdAt, error, isLoading };
+            if (response.data.type === "video" && isShortsVideo(tabUrl)) {
+                response.data.isShorts = true;
+            }
+
+            return {
+                data: response.data,
+                createdAt: response.createdAt,
+            };
+        },
+        enabled: isYoutubeVideo,
+    });
+
+    return {
+        query,
+        isYoutubeVideo,
+    };
 }

--- a/src/lib/analyticsUtils.ts
+++ b/src/lib/analyticsUtils.ts
@@ -21,8 +21,8 @@ export type UsageByDay = {
 //     };
 // };
 
-export async function getUsageByDay(): Promise<UsageByDay> {
-    return ((await getFromLocalCache("usageByDay")) ?? {}) as UsageByDay;
+export async function getUsageByDay() {
+    return (await getFromLocalCache<UsageByDay>("usageByDay")) ?? null;
 }
 
 /**

--- a/src/lib/analyticsUtils.ts
+++ b/src/lib/analyticsUtils.ts
@@ -22,7 +22,7 @@ export type UsageByDay = {
 // };
 
 export async function getUsageByDay() {
-    return (await getFromLocalCache<UsageByDay>("usageByDay")) ?? null;
+    return await getFromLocalCache<UsageByDay>("usageByDay");
 }
 
 /**

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -2,8 +2,8 @@ import CONFIG from "@lib/constants";
 import type { KickData, OptionsMap, StorageData, TwitchData, YoutubeData } from "@app-types/types";
 import { getDateKey } from "@lib/analyticsUtils";
 
-async function getCacheTTLSetting(): Promise<number> {
-    const cacheTTL = (await getFromSyncCache("cacheTTL")) as number;
+async function getCacheTTLSetting() {
+    const cacheTTL = await getFromSyncCache("cacheTTL");
     return cacheTTL || CONFIG.DEFAULT_CACHE_TTL;
 }
 
@@ -18,26 +18,31 @@ export async function setToSyncCache(input: OptionsMap) {
     return setToCache<OptionsMap>("sync", input);
 }
 
-async function getFromCache<T>(storage: "local" | "sync", key?: string | string[]): Promise<T> {
+async function getFromCache<T>(
+    storage: "local" | "sync",
+    key?: string | string[],
+): Promise<T | undefined> {
+    // Return all values if no key is provided
     if (!key) {
         return await chrome.storage[storage].get();
     }
+
     // If key is a single string/number, return just that value
     // If key is an array, return the object with all requested keys
     const data = await chrome.storage[storage].get(key);
 
     return (Array.isArray(key) ? data : data[key]) as T;
 }
-export async function getFromLocalCache(key?: string | string[]) {
-    return getFromCache("local", key);
+export async function getFromLocalCache<T>(key?: string | string[]) {
+    return getFromCache<T>("local", key);
 }
-export async function getAllFromSyncCache(): Promise<OptionsMap> {
+export async function getAllFromSyncCache() {
     return getFromCache<OptionsMap>("sync");
 }
-export async function getFromSyncCache<T extends keyof OptionsMap>(
+export async function getFromSyncCache<T extends keyof OptionsMap, K extends OptionsMap[T]>(
     key?: T | T[],
-): Promise<OptionsMap[T]> {
-    return getFromCache("sync", key);
+) {
+    return getFromCache<K>("sync", key);
 }
 
 async function removeFromCache(storage: "local" | "sync", key: string | string[]) {

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -18,31 +18,71 @@ export async function setToSyncCache(input: OptionsMap) {
     return setToCache<OptionsMap>("sync", input);
 }
 
+function getFromCache<T>(storage: "local" | "sync"): Promise<Record<string, T> | undefined>;
+
+function getFromCache<T>(storage: "local" | "sync", key: string): Promise<T | undefined>;
+
+function getFromCache<T>(
+    storage: "local" | "sync",
+    key: string[],
+): Promise<Record<string, T> | undefined>;
+
 async function getFromCache<T>(
     storage: "local" | "sync",
     key?: string | string[],
-): Promise<T | undefined> {
+): Promise<Record<string, T> | T | undefined> {
     // Return all values if no key is provided
-    if (!key) {
-        return await chrome.storage[storage].get();
+    if (key === undefined) {
+        return (await chrome.storage[storage].get()) as Record<string, T> | undefined;
+    }
+
+    const data = await chrome.storage[storage].get(key);
+
+    // If key is an array, return the object with all requested keys
+    if (Array.isArray(key)) {
+        return data as Record<string, T> | undefined;
     }
 
     // If key is a single string/number, return just that value
-    // If key is an array, return the object with all requested keys
-    const data = await chrome.storage[storage].get(key);
-
-    return (Array.isArray(key) ? data : data[key]) as T;
+    return data[key] as T | undefined;
 }
+
+export function getFromLocalCache<T>(): Promise<Record<string, T> | undefined>;
+export function getFromLocalCache<T>(key: string): Promise<T | undefined>;
+export function getFromLocalCache<T>(key: string[]): Promise<Record<string, T> | undefined>;
 export async function getFromLocalCache<T>(key?: string | string[]) {
+    if (key === undefined) {
+        return getFromCache<T>("local");
+    }
+    if (Array.isArray(key)) {
+        return getFromCache<T>("local", key);
+    }
     return getFromCache<T>("local", key);
 }
+
 export async function getAllFromSyncCache() {
     return getFromCache<OptionsMap>("sync");
 }
+
+export function getFromSyncCache<T extends keyof OptionsMap, K extends OptionsMap[T]>(): Promise<
+    Record<string, K>
+>;
+export function getFromSyncCache<T extends keyof OptionsMap, K extends OptionsMap[T]>(
+    key: T,
+): Promise<K>;
+export function getFromSyncCache<T extends keyof OptionsMap, K extends OptionsMap[T]>(
+    key: T[],
+): Promise<Record<string, K>>;
 export async function getFromSyncCache<T extends keyof OptionsMap, K extends OptionsMap[T]>(
     key?: T | T[],
 ) {
-    return getFromCache<K>("sync", key);
+    if (!key) {
+        return getFromCache<K>("sync");
+    }
+    if (Array.isArray(key)) {
+        return getFromCache<K>("sync", key as string[]);
+    }
+    return getFromCache<K>("sync", key as string);
 }
 
 async function removeFromCache(storage: "local" | "sync", key: string | string[]) {

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+    return twMerge(clsx(inputs));
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import type { OptionsMap } from "@app-types/types";
+
 const VIDEO_ITAGS = new Map([
     [144, [394, 330, 278, 160]],
     [240, [395, 331, 242, 133]],
@@ -22,6 +24,8 @@ const ttlInSecondsToDays = Object.fromEntries(
 
 const DEFAULT_CACHE_TTL = ttlInSecondsOptions["3"];
 
+const DEFAULT_TOASTER_THRESHOLD_UNIT: OptionsMap["toasterThresholdUnit"] = "mbPerHour";
+
 const optionIDs = ["p144", "p240", "p360", "p480", "p720", "p1080", "p1440", "p2160", "p4320"];
 
 const CONFIG = {
@@ -40,7 +44,7 @@ const CONFIG = {
     YT_INITIAL_PLAYER_REGEX: /ytInitialPlayerResponse\s*=\s*(\{.+?\});/s,
     CACHE_JUST_NOW_THRESHOLD: 5000,
     DEFAULT_TOASTER_THRESHOLD: 500,
-    DEFAULT_TOASTER_THRESHOLD_UNIT: "mbPerHour",
+    DEFAULT_TOASTER_THRESHOLD_UNIT,
     TOASTER_POLLING_INTERVAL: 5000,
     DEFAULT_TOASTER_ENABLED: true,
     DEFAULT_QUALITY_MENU_ENABLED: true,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,11 +10,17 @@ const VIDEO_ITAGS = new Map([
     [4320, [402, 571, 272, 138]],
 ]);
 
-const ttlInSecondsOptions: Map<string, number> = new Map([
-    ["1", 1 * 24 * 60 * 60],
-    ["3", 3 * 24 * 60 * 60],
-    ["7", 7 * 24 * 60 * 60],
-]);
+const ttlInSecondsOptions = {
+    "1": 1 * 24 * 60 * 60,
+    "3": 3 * 24 * 60 * 60,
+    "7": 7 * 24 * 60 * 60,
+} as const;
+
+const ttlInSecondsToDays = Object.fromEntries(
+    Object.entries(ttlInSecondsOptions).map(([key, value]) => [value, key]),
+);
+
+const DEFAULT_CACHE_TTL = ttlInSecondsOptions["3"];
 
 const optionIDs = ["p144", "p240", "p360", "p480", "p720", "p1080", "p1440", "p2160", "p4320"];
 
@@ -24,8 +30,9 @@ const CONFIG = {
     liveResolutions: [248, 247, 244, 243, 242, 278],
     AUDIO_ITAG: 251,
     LIVE_AUDIO_ITAG: 140,
-    DEFAULT_CACHE_TTL: 3 * 24 * 60 * 60, // 3 Days
+    DEFAULT_CACHE_TTL,
     ttlInSecondsOptions,
+    ttlInSecondsToDays,
     optionIDs,
     DEFAULT_MAX_RETRIES: 3,
     RANGE_RESOLUTION_THRESHOLD: 1080,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import TodayUsage from "@pages/analytics/todayUsage";
 import WeekUsage from "@pages/analytics/weekUsage";
 import MonthUsage from "@pages/analytics/monthUsage";
 import LifetimeUsage from "@pages/analytics/lifeTimeUsage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import "@styles/global.css";
 import "@fontsource-variable/jetbrains-mono/wght.css";
@@ -20,28 +21,31 @@ import AnalyticsLayout from "./layouts/analyticsLayout";
 const domRoot = document.querySelector("#root") as HTMLElement;
 
 const root = createRoot(domRoot);
+const queryClient = new QueryClient();
 
 root.render(
     <StrictMode>
-        <HashRouter>
-            <ErrorBoundary errorComponent={(err) => <ErrorPage errorMessage={err.message} />}>
-                <Routes>
-                    <Route path="/" element={<PopupLayout />}>
-                        <Route index element={<Popup />} />
-                    </Route>
+        <QueryClientProvider client={queryClient}>
+            <HashRouter>
+                <ErrorBoundary errorComponent={(err) => <ErrorPage errorMessage={err.message} />}>
+                    <Routes>
+                        <Route path="/" element={<PopupLayout />}>
+                            <Route index element={<Popup />} />
+                        </Route>
 
-                    <Route path="/options" element={<Options />} />
+                        <Route path="/options" element={<Options />} />
 
-                    <Route path="/analytics" element={<AnalyticsLayout />}>
-                        <Route index element={<Analytics />} />
-                        <Route path=":date" element={<UsageDetails />} />
-                        <Route path="today" element={<TodayUsage />} />
-                        <Route path="week" element={<WeekUsage />} />
-                        <Route path="month" element={<MonthUsage />} />
-                        <Route path="lifetime" element={<LifetimeUsage />} />
-                    </Route>
-                </Routes>
-            </ErrorBoundary>
-        </HashRouter>
+                        <Route path="/analytics" element={<AnalyticsLayout />}>
+                            <Route index element={<Analytics />} />
+                            <Route path=":date" element={<UsageDetails />} />
+                            <Route path="today" element={<TodayUsage />} />
+                            <Route path="week" element={<WeekUsage />} />
+                            <Route path="month" element={<MonthUsage />} />
+                            <Route path="lifetime" element={<LifetimeUsage />} />
+                        </Route>
+                    </Routes>
+                </ErrorBoundary>
+            </HashRouter>
+        </QueryClientProvider>
     </StrictMode>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,8 +15,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "@styles/global.css";
 import "@fontsource-variable/jetbrains-mono/wght.css";
 import { StrictMode } from "react";
-import { PopupLayout } from "./layouts/popupLayout";
-import AnalyticsLayout from "./layouts/analyticsLayout";
+import { PopupLayout } from "@layouts/popupLayout";
+import AnalyticsLayout from "@layouts/analyticsLayout";
 
 const domRoot = document.querySelector("#root") as HTMLElement;
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -26,9 +26,9 @@ void (async () => {
             if (!videoTag) continue;
 
             const date = getDateKey(new Date());
-            const usageByDay = await getUsageByDay();
-            usageByDay[date] ??= {};
-            usageByDay[date][videoTag] ??= {
+            const usageByDay = (await getUsageByDay()) ?? {};
+            const todayUsage = usageByDay[date] ?? {};
+            todayUsage[videoTag] = {
                 usage: 0,
                 title: undefined,
                 thumbnailUrl: undefined,
@@ -48,14 +48,15 @@ void (async () => {
                     continue;
                 }
 
-                usageByDay[date][videoTag].title =
+                todayUsage[videoTag].title =
                     res.data.type === "video" ? res.data.title : res.data.channelName || "Youtube";
-                usageByDay[date][videoTag].thumbnailUrl =
+                todayUsage[videoTag].thumbnailUrl =
                     res.data.thumbnailUrl || "https://www.youtube.com/img/desktop/yt_1200.png";
-                usageByDay[date][videoTag].channelName = res.data.channelName;
+                todayUsage[videoTag].channelName = res.data.channelName;
                 CACHED_VIDEOS.add(videoTag);
             }
-            usageByDay[date][videoTag].usage = oldUsage + pendingUsage;
+            todayUsage[videoTag].usage = oldUsage + pendingUsage;
+            usageByDay[date] = todayUsage;
             updateBadge(usageByDay);
             await setToLocalCache({ usageByDay });
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -17,7 +17,7 @@ function getCurrentTabUrl() {
 }
 
 void (async () => {
-    const CACHED_VIDEOS = new Set<string>();
+    const cachedVideos = new Set<string>();
     do {
         try {
             if (pendingUsage === 0) continue;
@@ -27,18 +27,21 @@ void (async () => {
 
             const date = getDateKey(new Date());
             const usageByDay = (await getUsageByDay()) ?? {};
-            const todayUsage = usageByDay[date] ?? {};
-            todayUsage[videoTag] = {
+
+            let todayUsage = usageByDay[date];
+            if (!todayUsage) {
+                todayUsage = {};
+                usageByDay[date] = todayUsage;
+            }
+            const videoUsage = (todayUsage[videoTag] ??= {
                 usage: 0,
                 title: undefined,
                 thumbnailUrl: undefined,
                 channelName: undefined,
-            };
+            });
 
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            const oldUsage = usageByDay?.[date]?.[videoTag]?.usage || 0;
-
-            if (!CACHED_VIDEOS.has(videoTag)) {
+            // Get video info from background script if not cached
+            if (!cachedVideos.has(videoTag)) {
                 const res = await sendMessageToBackground({
                     type: "youtubeVideo",
                     videoTag,
@@ -48,15 +51,15 @@ void (async () => {
                     continue;
                 }
 
-                todayUsage[videoTag].title =
+                videoUsage.title =
                     res.data.type === "video" ? res.data.title : res.data.channelName || "Youtube";
-                todayUsage[videoTag].thumbnailUrl =
+                videoUsage.thumbnailUrl =
                     res.data.thumbnailUrl || "https://www.youtube.com/img/desktop/yt_1200.png";
-                todayUsage[videoTag].channelName = res.data.channelName;
-                CACHED_VIDEOS.add(videoTag);
+                videoUsage.channelName = res.data.channelName;
+                cachedVideos.add(videoTag);
             }
-            todayUsage[videoTag].usage = oldUsage + pendingUsage;
-            usageByDay[date] = todayUsage;
+            videoUsage.usage += pendingUsage;
+
             updateBadge(usageByDay);
             await setToLocalCache({ usageByDay });
 
@@ -69,8 +72,6 @@ void (async () => {
         }
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition , no-constant-condition
     } while (true);
-})().catch((err) => {
-    console.error("Error in usage tracking loop:", err);
 });
 
 observer.observe({

--- a/src/pages/analytics/analytics.tsx
+++ b/src/pages/analytics/analytics.tsx
@@ -88,41 +88,32 @@ function UsageChartSection({
 }
 
 function ClearUsageButton() {
-    const { clearUsage, isClearing, isClearingError, isClearingSuccess } = useUsage();
-
-    // const handleClearUsageData = () => {
-    //     if (!confirm("Are you sure you want to clear all usage data?")) return;
-    //     try {
-    //         setClearStatus("success");
-    //     } catch (err) {
-    //         console.error("Failed to clear usage data", err);
-    //         setClearStatus("error");
-    //     } finally {
-    //         setTimeout(() => {
-    //             setClearStatus("idle");
-    //             setIsClearing(false);
-    //         }, 1500);
-    //     }
-    // };
-
-    // const clearButtonText =
-    //     clearStatus === "success"
-    //         ? "Usage Data Cleared Successfully!"
-    //         : clearStatus === "error"
-    //           ? "Failed to Clear Usage Data. Try Again."
-    //           : "Clear All Usage Data";
-    //
+    const { clearUsageMutation } = useUsage();
+    const {
+        mutate: clearUsage,
+        isPending: isClearingPending,
+        isError: isClearingError,
+        isSuccess: isClearingSuccess,
+        reset: resetClearing,
+        isIdle: isClearingIdle,
+    } = clearUsageMutation;
 
     return (
         <button
             className="mt-2.5 cursor-pointer rounded-xl border border-neutral-800 bg-[#221718] px-3 py-2.5 font-mono text-xs font-semibold tracking-widest text-red-400 uppercase transition-colors hover:bg-[#2a1b1c]"
-            onClick={() => clearUsage()}
-            disabled={isClearing}
+            onClick={() => {
+                clearUsage();
+
+                setTimeout(() => {
+                    resetClearing();
+                }, 2500);
+            }}
+            disabled={isClearingPending}
         >
-            {isClearing && "Clearing"}
+            {isClearingPending && "Clearing"}
             {isClearingError && "Failed To Clear Usage Data. Try Again."}
             {isClearingSuccess && "Usage Data was Cleared Successfully"}
-            {!isClearing && !isClearingError && "Clear All Usage  Data"}
+            {isClearingIdle && "Clear All Usage Data"}
         </button>
     );
 }

--- a/src/pages/analytics/analytics.tsx
+++ b/src/pages/analytics/analytics.tsx
@@ -1,5 +1,3 @@
-import { removeFromLocalCache } from "@lib/cache";
-import { useState } from "react";
 import Chart from "./chart";
 import {
     isEmptyUsageByDay,
@@ -89,59 +87,61 @@ function UsageChartSection({
     );
 }
 
-function ClearUsageButton({ setUsage }: { setUsage: (UsageByDay: UsageByDay) => void }) {
-    const [isClearing, setIsClearing] = useState(false);
-    const [clearStatus, setClearStatus] = useState<"idle" | "success" | "error">("idle");
-    const handleClearUsageData = async () => {
-        if (!confirm("Are you sure you want to clear all usage data?")) return;
-        setIsClearing(true);
-        try {
-            await clearAllUsageData();
-            setUsage({});
-            setClearStatus("success");
-        } catch (err) {
-            console.error("Failed to clear usage data", err);
-            setClearStatus("error");
-        } finally {
-            setTimeout(() => {
-                setClearStatus("idle");
-                setIsClearing(false);
-            }, 1500);
-        }
-    };
+function ClearUsageButton() {
+    const { clearUsage, isClearing, isClearingError, isClearingSuccess } = useUsage();
 
-    const clearButtonText =
-        clearStatus === "success"
-            ? "Usage Data Cleared Successfully!"
-            : clearStatus === "error"
-              ? "Failed to Clear Usage Data. Try Again."
-              : "Clear All Usage Data";
+    // const handleClearUsageData = () => {
+    //     if (!confirm("Are you sure you want to clear all usage data?")) return;
+    //     try {
+    //         setClearStatus("success");
+    //     } catch (err) {
+    //         console.error("Failed to clear usage data", err);
+    //         setClearStatus("error");
+    //     } finally {
+    //         setTimeout(() => {
+    //             setClearStatus("idle");
+    //             setIsClearing(false);
+    //         }, 1500);
+    //     }
+    // };
+
+    // const clearButtonText =
+    //     clearStatus === "success"
+    //         ? "Usage Data Cleared Successfully!"
+    //         : clearStatus === "error"
+    //           ? "Failed to Clear Usage Data. Try Again."
+    //           : "Clear All Usage Data";
+    //
 
     return (
         <button
             className="mt-2.5 cursor-pointer rounded-xl border border-neutral-800 bg-[#221718] px-3 py-2.5 font-mono text-xs font-semibold tracking-widest text-red-400 uppercase transition-colors hover:bg-[#2a1b1c]"
-            onClick={() => void handleClearUsageData()}
+            onClick={() => clearUsage()}
             disabled={isClearing}
         >
-            {clearButtonText}
+            {isClearing && "Clearing"}
+            {isClearingError && "Failed To Clear Usage Data. Try Again."}
+            {isClearingSuccess && "Usage Data was Cleared Successfully"}
+            {!isClearing && !isClearingError && "Clear All Usage  Data"}
         </button>
     );
 }
 
-async function clearAllUsageData() {
-    await removeFromLocalCache("usageByDay");
-}
-
 export default function Analytics() {
-    const { usage, setUsage, error } = useUsage();
+    const { query } = useUsage();
+    const { data: usage, isPending, isError } = query;
+
+    if (isPending) return <div>isLoading</div>;
+    if (isError) return <div>Error</div>;
+    if (!usage) return <div>No usage data available.</div>;
 
     return (
         <>
             <AnalyticsHeader />
             <div className="flex flex-1 flex-col bg-neutral-950/70 px-8 pt-1 pb-3.5">
                 <StatsRow usage={usage} />
-                <UsageChartSection usage={usage} errorMessage={error?.message} />
-                <ClearUsageButton setUsage={setUsage} />
+                <UsageChartSection usage={usage} errorMessage={undefined} />
+                <ClearUsageButton />
             </div>
         </>
     );

--- a/src/pages/analytics/analytics.tsx
+++ b/src/pages/analytics/analytics.tsx
@@ -1,4 +1,4 @@
-import Chart from "./chart";
+import Chart from "@pages/analytics/chart";
 import {
     isEmptyUsageByDay,
     type UsageByDay,

--- a/src/pages/analytics/analyticsBody.tsx
+++ b/src/pages/analytics/analyticsBody.tsx
@@ -1,5 +1,5 @@
 import { isEmptyUsageByDay, type UsageByDay } from "@/lib/analyticsUtils";
-import VideosTable from "./videosTable";
+import VideosTable from "@pages/analytics/videosTable";
 
 export default function AnalyticsBody({ usage }: { usage: UsageByDay }) {
     return (

--- a/src/pages/analytics/analyticsBody.tsx
+++ b/src/pages/analytics/analyticsBody.tsx
@@ -1,21 +1,14 @@
 import { isEmptyUsageByDay, type UsageByDay } from "@/lib/analyticsUtils";
 import VideosTable from "./videosTable";
 
-export default function AnalyticsBody({
-    usage,
-    error,
-}: {
-    usage: UsageByDay;
-    error: Error | undefined;
-}) {
+export default function AnalyticsBody({ usage }: { usage: UsageByDay }) {
     return (
         <div className="flex flex-1 bg-neutral-950 p-8">
             <div className="flex flex-1 flex-col rounded-2xl border border-neutral-800 bg-neutral-900">
                 <VideosTable usage={usage} />
-                {(isEmptyUsageByDay(usage) || error) && (
+                {isEmptyUsageByDay(usage) && (
                     <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-neutral-700 bg-neutral-900 font-mono text-base text-teal-400">
-                        {error?.message ??
-                            "No data available. Watch a YouTube video to see your usage statistics."}
+                        No data available. Watch a YouTube video to see your usage statistics.
                     </div>
                 )}
             </div>

--- a/src/pages/analytics/lifeTimeUsage.tsx
+++ b/src/pages/analytics/lifeTimeUsage.tsx
@@ -1,6 +1,6 @@
 import { formatDate, getNumVideosWatched, getUsageNumber } from "@lib/analyticsUtils";
-import AnalyticsHeader from "./analyticsHeader";
-import AnalyticsBody from "./analyticsBody";
+import AnalyticsHeader from "@pages/analytics/analyticsHeader";
+import AnalyticsBody from "@pages/analytics/analyticsBody";
 import useUsage from "@/hooks/useUsage";
 
 export default function LifetimeUsage() {

--- a/src/pages/analytics/lifeTimeUsage.tsx
+++ b/src/pages/analytics/lifeTimeUsage.tsx
@@ -4,7 +4,13 @@ import AnalyticsBody from "./analyticsBody";
 import useUsage from "@/hooks/useUsage";
 
 export default function LifetimeUsage() {
-    const { usage: lifeTimeUsage, error } = useUsage();
+    const { query } = useUsage();
+    const { data: lifeTimeUsage, isPending, isError } = query;
+
+    if (isPending) return <div>Loading...</div>;
+    if (isError) return <div>Error loading usage.</div>;
+    if (!lifeTimeUsage) return <div>No usage data available.</div>;
+
     const sortedDates = Object.keys(lifeTimeUsage)
         .map((key) => new Date(key))
         .sort((a, b) => a.getTime() - b.getTime());
@@ -17,7 +23,7 @@ export default function LifetimeUsage() {
                 totalDataUsage={getUsageNumber(lifeTimeUsage)}
                 numVideosWatched={getNumVideosWatched(lifeTimeUsage)}
             />
-            <AnalyticsBody usage={lifeTimeUsage} error={error} />
+            <AnalyticsBody usage={lifeTimeUsage} />
         </>
     );
 }

--- a/src/pages/analytics/monthUsage.tsx
+++ b/src/pages/analytics/monthUsage.tsx
@@ -10,7 +10,12 @@ import AnalyticsBody from "./analyticsBody";
 import useUsage from "@/hooks/useUsage";
 
 export default function MonthUsage() {
-    const { usage, error } = useUsage();
+    const { query } = useUsage();
+    const { data: usage, isPending, isError } = query;
+    if (isPending) return <div>Loading...</div>;
+    if (isError) return <div>Error loading usage.</div>;
+    if (!usage) return <div>No usage data available.</div>;
+
     const monthUsage = getLast30DaysUsage(usage);
 
     return (
@@ -20,7 +25,7 @@ export default function MonthUsage() {
                 totalDataUsage={getUsageNumber(monthUsage)}
                 numVideosWatched={getNumVideosWatched(monthUsage)}
             />
-            <AnalyticsBody usage={monthUsage} error={error} />
+            <AnalyticsBody usage={monthUsage} />
         </>
     );
 }

--- a/src/pages/analytics/monthUsage.tsx
+++ b/src/pages/analytics/monthUsage.tsx
@@ -5,8 +5,8 @@ import {
     getLast30DaysUsage,
     getUsageNumber,
 } from "@lib/analyticsUtils";
-import AnalyticsHeader from "./analyticsHeader";
-import AnalyticsBody from "./analyticsBody";
+import AnalyticsHeader from "@pages/analytics/analyticsHeader";
+import AnalyticsBody from "@pages/analytics/analyticsBody";
 import useUsage from "@/hooks/useUsage";
 
 export default function MonthUsage() {

--- a/src/pages/analytics/todayUsage.tsx
+++ b/src/pages/analytics/todayUsage.tsx
@@ -4,8 +4,8 @@ import {
     getTodayUsage,
     getUsageNumber,
 } from "@lib/analyticsUtils";
-import AnalyticsHeader from "./analyticsHeader";
-import AnalyticsBody from "./analyticsBody";
+import AnalyticsHeader from "@pages/analytics/analyticsHeader";
+import AnalyticsBody from "@pages/analytics/analyticsBody";
 import useUsage from "@/hooks/useUsage";
 
 export default function TodayUsage() {

--- a/src/pages/analytics/todayUsage.tsx
+++ b/src/pages/analytics/todayUsage.tsx
@@ -9,7 +9,12 @@ import AnalyticsBody from "./analyticsBody";
 import useUsage from "@/hooks/useUsage";
 
 export default function TodayUsage() {
-    const { usage, error } = useUsage();
+    const { query } = useUsage();
+    const { data: usage, isPending, isError } = query;
+    if (isPending) return <div>Loading...</div>;
+    if (isError) return <div>Error loading usage.</div>;
+    if (!usage) return <div>No usage data available.</div>;
+
     const todayUsage = getTodayUsage(usage);
 
     return (
@@ -19,7 +24,7 @@ export default function TodayUsage() {
                 totalDataUsage={getUsageNumber(todayUsage)}
                 numVideosWatched={getNumVideosWatched(todayUsage)}
             />
-            <AnalyticsBody usage={todayUsage} error={error} />
+            <AnalyticsBody usage={todayUsage} />
         </>
     );
 }

--- a/src/pages/analytics/usageDetails.tsx
+++ b/src/pages/analytics/usageDetails.tsx
@@ -10,9 +10,14 @@ import AnalyticsBody from "./analyticsBody";
 import useUsage from "@/hooks/useUsage";
 
 export function UsageDetails() {
-    const { usage, error } = useUsage();
+    const { query } = useUsage();
+    const { data: usage, isPending, isError } = query;
     const { date } = useParams();
+
     if (!date) return;
+    if (isPending) return <div>Loading...</div>;
+    if (isError) return <div>Error loading usage.</div>;
+    if (!usage) return <div>No usage data available.</div>;
 
     const daysUsage = getUsageByDate(usage, date);
 
@@ -24,7 +29,7 @@ export function UsageDetails() {
                 totalDataUsage={getUsageNumber(daysUsage)}
                 key={date}
             />
-            <AnalyticsBody usage={daysUsage} error={error} />
+            <AnalyticsBody usage={daysUsage} />
         </>
     );
 }

--- a/src/pages/analytics/usageDetails.tsx
+++ b/src/pages/analytics/usageDetails.tsx
@@ -5,8 +5,8 @@ import {
     formatDate,
 } from "@lib/analyticsUtils";
 import { useParams } from "react-router";
-import AnalyticsHeader from "./analyticsHeader";
-import AnalyticsBody from "./analyticsBody";
+import AnalyticsHeader from "@pages/analytics/analyticsHeader";
+import AnalyticsBody from "@pages/analytics/analyticsBody";
 import useUsage from "@/hooks/useUsage";
 
 export function UsageDetails() {

--- a/src/pages/analytics/videosTable.tsx
+++ b/src/pages/analytics/videosTable.tsx
@@ -1,5 +1,5 @@
 import { getSortedVideoUsageRows, type UsageByDay } from "@/lib/analyticsUtils";
-import VideoTableRow from "./videoTableRow";
+import VideoTableRow from "@pages/analytics/videoTableRow";
 import { useMemo } from "react";
 
 export default function VideosTable({ usage }: { usage: UsageByDay }) {

--- a/src/pages/analytics/weekUsage.tsx
+++ b/src/pages/analytics/weekUsage.tsx
@@ -10,7 +10,12 @@ import AnalyticsBody from "./analyticsBody";
 import useUsage from "@/hooks/useUsage";
 
 export default function WeekUsage() {
-    const { usage, error } = useUsage();
+    const { query } = useUsage();
+    const { data: usage, isPending, isError } = query;
+    if (isPending) return <div>Loading...</div>;
+    if (isError) return <div>Error loading usage.</div>;
+    if (!usage) return <div>No usage data available.</div>;
+
     const weekUsage = getLast7DaysUsage(usage);
 
     return (
@@ -20,7 +25,7 @@ export default function WeekUsage() {
                 totalDataUsage={getUsageNumber(weekUsage)}
                 numVideosWatched={getNumVideosWatched(weekUsage)}
             />
-            <AnalyticsBody usage={weekUsage} error={error} />
+            <AnalyticsBody usage={weekUsage} />
         </>
     );
 }

--- a/src/pages/analytics/weekUsage.tsx
+++ b/src/pages/analytics/weekUsage.tsx
@@ -5,8 +5,8 @@ import {
     formatDate,
     getLast7DaysUsage,
 } from "@lib/analyticsUtils";
-import AnalyticsHeader from "./analyticsHeader";
-import AnalyticsBody from "./analyticsBody";
+import AnalyticsHeader from "@pages/analytics/analyticsHeader";
+import AnalyticsBody from "@pages/analytics/analyticsBody";
 import useUsage from "@/hooks/useUsage";
 
 export default function WeekUsage() {

--- a/src/pages/options/cacheSettings.tsx
+++ b/src/pages/options/cacheSettings.tsx
@@ -1,13 +1,7 @@
 import useOptions from "@hooks/useOptions";
 import CONFIG from "@lib/constants";
 import type { OptionsMap } from "@app-types/types";
-
-const stateStyles = {
-    idle: "border-red-500/20 bg-red-500/8 text-red-400 hover:border-red-500/40 hover:bg-red-500/18",
-    success: "border-green-500/40 bg-green-500/8 text-green-500",
-    error: "border-red-500/20 bg-red-500/8 text-red-400",
-    pending: "",
-} as const;
+import { cn } from "@lib/cn";
 
 export default function CacheSettings({ optionsState }: { optionsState: OptionsMap }) {
     const { updateOptionsMutation } = useOptions();
@@ -50,7 +44,18 @@ export default function CacheSettings({ optionsState }: { optionsState: OptionsM
             </div>
             <button
                 id="resetCache"
-                className={`w-full cursor-pointer rounded-md border px-2.5 py-2 text-center text-xs font-medium transition-all disabled:cursor-default ${stateStyles[clearingStatus]}`}
+                className={cn(
+                    "w-full cursor-pointer rounded-md border px-2.5 py-2 text-center text-xs font-medium transition-all disabled:cursor-default",
+                    {
+                        "border-red-500/20 bg-red-500/8 text-red-400 hover:border-red-500/40 hover:bg-red-500/18":
+                            clearingStatus === "idle",
+
+                        "border-green-500/40 bg-green-500/8 text-green-500":
+                            clearingStatus === "success",
+
+                        "border-red-500/20 bg-red-500/8 text-red-400": clearingStatus === "error",
+                    },
+                )}
                 disabled={clearingIsPending}
                 onClick={() => {
                     clearLocalCache();

--- a/src/pages/options/cacheSettings.tsx
+++ b/src/pages/options/cacheSettings.tsx
@@ -1,29 +1,27 @@
-import { useState } from "react";
-import { clearLocalCache } from "@lib/cache";
 import useOptions from "@hooks/useOptions";
 import CONFIG from "@lib/constants";
-
-function convertDaysToSeconds(days: number | string) {
-    return Number(days) * 24 * 60 * 60;
-}
-
-function convertSecondsToDays(seconds: number | string) {
-    return String(Math.round(Number(seconds) / (24 * 60 * 60)));
-}
+import type { OptionsMap } from "@app-types/types";
 
 const stateStyles = {
     idle: "border-red-500/20 bg-red-500/8 text-red-400 hover:border-red-500/40 hover:bg-red-500/18",
     success: "border-green-500/40 bg-green-500/8 text-green-500",
-    fail: "border-red-500/20 bg-red-500/8 text-red-400",
+    error: "border-red-500/20 bg-red-500/8 text-red-400",
+    pending: "",
 } as const;
 
-export default function CacheSettings() {
-    const [clearCache, setClearCache] = useState<"idle" | "success" | "fail">("idle");
-    const [disableClearCache, setDisableClearCache] = useState(false);
-    const { query, updateOptions } = useOptions();
-    const { data: optionsState, isPending, isError } = query;
-    if (isPending) return <div>Loading...</div>;
-    if (isError) return <div>Error loading options.</div>;
+export default function CacheSettings({ optionsState }: { optionsState: OptionsMap }) {
+    const { updateOptionsMutation } = useOptions();
+    const { mutate: updateOptions } = updateOptionsMutation;
+    const { clearCacheMutation } = useOptions();
+    const {
+        mutate: clearLocalCache,
+        isPending: clearingIsPending,
+        isSuccess: clearingIsSuccess,
+        isError: clearingIsError,
+        status: clearingStatus,
+        isIdle: clearingIsIdle,
+        reset: resetClearingStatus,
+    } = clearCacheMutation;
 
     return (
         <div className="p-3">
@@ -36,46 +34,33 @@ export default function CacheSettings() {
                     id="cacheTTL"
                     className="cursor-pointer rounded border border-white/15 bg-zinc-800 p-1 outline-none focus:border-sky-400"
                     value={
-                        convertSecondsToDays(optionsState.cacheTTL ?? CONFIG.DEFAULT_CACHE_TTL) ||
-                        "3"
-                    } // Fallback to "3" days if undefined
+                        CONFIG.ttlInSecondsToDays[optionsState.cacheTTL ?? CONFIG.DEFAULT_CACHE_TTL]
+                    }
                     onChange={(event) => {
-                        const days = event.target.value;
-                        const ttlInSeconds = convertDaysToSeconds(days);
-                        updateOptions({
-                            cacheTTL: ttlInSeconds,
-                        });
+                        const days = event.target.value as keyof typeof CONFIG.ttlInSecondsOptions;
+                        updateOptions({ cacheTTL: CONFIG.ttlInSecondsOptions[days] });
                     }}
                 >
-                    <option value="1">1 Day</option>
-                    <option value="3">3 Days</option>
-                    <option value="7">7 Days</option>
+                    {Object.keys(CONFIG.ttlInSecondsOptions).map((days) => (
+                        <option key={days} value={days}>
+                            {days} Day{days === "1" ? "" : "s"}
+                        </option>
+                    ))}
                 </select>
             </div>
             <button
                 id="resetCache"
-                className={`w-full cursor-pointer rounded-md border px-2.5 py-2 text-center text-xs font-medium transition-all disabled:cursor-default ${stateStyles[clearCache]}`}
-                disabled={disableClearCache}
+                className={`w-full cursor-pointer rounded-md border px-2.5 py-2 text-center text-xs font-medium transition-all disabled:cursor-default ${stateStyles[clearingStatus]}`}
+                disabled={clearingIsPending}
                 onClick={() => {
-                    setDisableClearCache(true);
-                    void clearLocalCache()
-                        .then(() => {
-                            setClearCache("success");
-                            setTimeout(() => {
-                                setClearCache("idle");
-                                setDisableClearCache(false);
-                            }, 2000);
-                            return;
-                        })
-                        .catch(() => {
-                            setClearCache("fail");
-                            setDisableClearCache(false);
-                        });
+                    clearLocalCache();
+                    setTimeout(resetClearingStatus, 3000);
                 }}
             >
-                {clearCache === "idle" && "Clear Cache"}
-                {clearCache === "success" && "Cache Cleared Successfully"}
-                {clearCache === "fail" && "Failed to Clear Cache"}
+                {clearingIsIdle && "Clear Cache"}
+                {clearingIsPending && "Clearing the Cache..."}
+                {clearingIsSuccess && "Cache Cleared Successfully"}
+                {clearingIsError && "Failed to Clear Cache"}
             </button>
         </div>
     );

--- a/src/pages/options/cacheSettings.tsx
+++ b/src/pages/options/cacheSettings.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { setToSyncCache, clearLocalCache } from "@lib/cache";
+import { clearLocalCache } from "@lib/cache";
 import useOptions from "@hooks/useOptions";
 import CONFIG from "@lib/constants";
 
@@ -20,7 +20,10 @@ const stateStyles = {
 export default function CacheSettings() {
     const [clearCache, setClearCache] = useState<"idle" | "success" | "fail">("idle");
     const [disableClearCache, setDisableClearCache] = useState(false);
-    const { optionsState, setOptionsState } = useOptions();
+    const { query, updateOptions } = useOptions();
+    const { data: optionsState, isPending, isError } = query;
+    if (isPending) return <div>Loading...</div>;
+    if (isError) return <div>Error loading options.</div>;
 
     return (
         <div className="p-3">
@@ -39,13 +42,9 @@ export default function CacheSettings() {
                     onChange={(event) => {
                         const days = event.target.value;
                         const ttlInSeconds = convertDaysToSeconds(days);
-                        void setToSyncCache({
+                        updateOptions({
                             cacheTTL: ttlInSeconds,
-                        }).catch(() => {});
-                        setOptionsState((prev) => ({
-                            ...prev,
-                            cacheTTL: ttlInSeconds,
-                        }));
+                        });
                     }}
                 >
                     <option value="1">1 Day</option>

--- a/src/pages/options/optionItem.tsx
+++ b/src/pages/options/optionItem.tsx
@@ -8,7 +8,8 @@ export default function OptionItem({
     option: string;
     optionsState: OptionsMap;
 }) {
-    const { updateOptions } = useOptions();
+    const { updateOptionsMutation } = useOptions();
+    const { mutate: updateOptions } = updateOptionsMutation;
 
     return (
         <div className="flex cursor-pointer items-center justify-between rounded-lg border border-transparent bg-white/3 px-3 py-2.5 pl-3 transition-all hover:border-white/20 hover:bg-white/8">
@@ -21,7 +22,7 @@ export default function OptionItem({
                 checked={optionsState["qualityIds"]?.[option] ?? true}
                 onChange={(event) => {
                     const { checked } = event.target;
-                    void updateOptions({
+                    updateOptions({
                         qualityIds: {
                             ...optionsState["qualityIds"],
                             [option]: checked,

--- a/src/pages/options/optionItem.tsx
+++ b/src/pages/options/optionItem.tsx
@@ -1,15 +1,15 @@
+import useOptions from "@/hooks/useOptions";
 import type { OptionsMap } from "@app-types/types";
-import { setToSyncCache } from "@lib/cache";
 
 export default function OptionItem({
     option,
     optionsState,
-    setOptionsState,
 }: {
     option: string;
     optionsState: OptionsMap;
-    setOptionsState: (optionsState: OptionsMap) => void;
 }) {
+    const { updateOptions } = useOptions();
+
     return (
         <div className="flex cursor-pointer items-center justify-between rounded-lg border border-transparent bg-white/3 px-3 py-2.5 pl-3 transition-all hover:border-white/20 hover:bg-white/8">
             <label className="cursor-pointer text-xs font-medium text-white" htmlFor={option}>
@@ -21,30 +21,14 @@ export default function OptionItem({
                 checked={optionsState["qualityIds"]?.[option] ?? true}
                 onChange={(event) => {
                     const { checked } = event.target;
-                    void handleOptionChange(option, checked, optionsState, setOptionsState);
+                    void updateOptions({
+                        qualityIds: {
+                            ...optionsState["qualityIds"],
+                            [option]: checked,
+                        },
+                    });
                 }}
             ></input>
         </div>
     );
-}
-
-async function handleOptionChange(
-    option: string,
-    isChecked: boolean,
-    optionsState: OptionsMap,
-    setOptionsState: (optionsState: OptionsMap) => void,
-) {
-    await setToSyncCache({
-        qualityIds: {
-            ...optionsState["qualityIds"],
-            [option]: isChecked,
-        },
-    });
-    setOptionsState({
-        ...optionsState,
-        qualityIds: {
-            ...optionsState["qualityIds"],
-            [option]: isChecked,
-        },
-    });
 }

--- a/src/pages/options/options.tsx
+++ b/src/pages/options/options.tsx
@@ -9,7 +9,12 @@ import Divider from "./divider";
 import { OptionsFooter } from "./optionsFooter";
 
 export default function Options() {
-    const { optionsState, setOptionsState } = useOptions();
+    const { query } = useOptions();
+
+    const { data: optionsState, isPending, isError } = query;
+    if (isPending) return <div>Loading...</div>;
+    if (isError) return <div>Error loading options.</div>;
+
     return (
         <div className="w-72.5">
             <HeaderOptions />
@@ -20,12 +25,7 @@ export default function Options() {
                 <div className="grid grid-cols-3 gap-2.5">
                     {CONFIG.optionIDs.map((option) => {
                         return (
-                            <OptionItem
-                                key={option}
-                                option={option}
-                                optionsState={optionsState}
-                                setOptionsState={setOptionsState}
-                            />
+                            <OptionItem key={option} option={option} optionsState={optionsState} />
                         );
                     })}
                 </div>

--- a/src/pages/options/options.tsx
+++ b/src/pages/options/options.tsx
@@ -1,12 +1,11 @@
-import CONFIG from "@lib/constants";
 import HeaderOptions from "./headerOptions";
-import OptionItem from "./optionItem";
 import CacheSettings from "./cacheSettings";
 import ToasterSettings from "./toasterSettings";
 import QualityMenu from "./qualityMenu";
 import useOptions from "@hooks/useOptions";
 import Divider from "./divider";
 import { OptionsFooter } from "./optionsFooter";
+import ResolutionsOptions from "./resolutionsOptions";
 
 export default function Options() {
     const { query } = useOptions();
@@ -18,27 +17,17 @@ export default function Options() {
     return (
         <div className="w-72.5">
             <HeaderOptions />
-            <div className="p-3">
-                <div className="mb-2 text-sm text-zinc-400">
-                    Select which resolutions to display:
-                </div>
-                <div className="grid grid-cols-3 gap-2.5">
-                    {CONFIG.optionIDs.map((option) => {
-                        return (
-                            <OptionItem key={option} option={option} optionsState={optionsState} />
-                        );
-                    })}
-                </div>
-            </div>
+
+            <ResolutionsOptions optionsState={optionsState} />
 
             <Divider />
             <CacheSettings optionsState={optionsState} />
 
             <Divider />
-            <ToasterSettings />
+            <ToasterSettings optionsState={optionsState} />
 
             <Divider />
-            <QualityMenu />
+            <QualityMenu optionsState={optionsState} />
 
             <Divider />
             <OptionsFooter />

--- a/src/pages/options/options.tsx
+++ b/src/pages/options/options.tsx
@@ -1,11 +1,11 @@
-import HeaderOptions from "./headerOptions";
-import CacheSettings from "./cacheSettings";
-import ToasterSettings from "./toasterSettings";
-import QualityMenu from "./qualityMenu";
+import HeaderOptions from "@pages/options/headerOptions";
+import CacheSettings from "@pages/options/cacheSettings";
+import ToasterSettings from "@pages/options/toasterSettings";
+import QualityMenu from "@pages/options/qualityMenu";
 import useOptions from "@hooks/useOptions";
-import Divider from "./divider";
-import { OptionsFooter } from "./optionsFooter";
-import ResolutionsOptions from "./resolutionsOptions";
+import Divider from "@pages/options/divider";
+import { OptionsFooter } from "@pages/options/optionsFooter";
+import ResolutionsOptions from "@pages/options/resolutionsOptions";
 
 export default function Options() {
     const { query } = useOptions();

--- a/src/pages/options/options.tsx
+++ b/src/pages/options/options.tsx
@@ -32,7 +32,7 @@ export default function Options() {
             </div>
 
             <Divider />
-            <CacheSettings />
+            <CacheSettings optionsState={optionsState} />
 
             <Divider />
             <ToasterSettings />

--- a/src/pages/options/qualityMenu.tsx
+++ b/src/pages/options/qualityMenu.tsx
@@ -1,21 +1,11 @@
-import { getFromSyncCache, setToSyncCache } from "@lib/cache";
+import type { OptionsMap } from "@app-types/types";
+import useOptions from "@hooks/useOptions";
 import CONFIG from "@lib/constants";
-import { useEffect, useState } from "react";
 
-export default function QualityMenu() {
-    const [qualityMenuEnabled, setQualityMenuEnabled] = useState<boolean>(
-        CONFIG.DEFAULT_QUALITY_MENU_ENABLED,
-    );
-
-    useEffect(() => {
-        void (async () => {
-            const isQualityMenuEnabled =
-                (await getFromSyncCache("qualityMenu")) ?? CONFIG.DEFAULT_QUALITY_MENU_ENABLED;
-            if (typeof isQualityMenuEnabled === "boolean") {
-                setQualityMenuEnabled(isQualityMenuEnabled);
-            }
-        })();
-    }, []);
+export default function QualityMenu({ optionsState }: { optionsState: OptionsMap }) {
+    const isQualityMenuEnabled = optionsState.qualityMenu ?? CONFIG.DEFAULT_QUALITY_MENU_ENABLED;
+    const { updateOptionsMutation } = useOptions();
+    const { mutate: updateOptions } = updateOptionsMutation;
 
     return (
         <div className="p-3.5">
@@ -32,12 +22,11 @@ export default function QualityMenu() {
                 <input
                     id="qualityMenuToggle"
                     type="checkbox"
-                    checked={qualityMenuEnabled}
+                    checked={isQualityMenuEnabled}
                     onChange={(event) => {
-                        const { checked } = event.target;
-                        void setToSyncCache({
-                            qualityMenu: checked,
-                        }).then(() => setQualityMenuEnabled(checked));
+                        updateOptions({
+                            qualityMenu: event.target.checked,
+                        });
                     }}
                 ></input>
             </div>

--- a/src/pages/options/resolutionsOptions.tsx
+++ b/src/pages/options/resolutionsOptions.tsx
@@ -1,0 +1,16 @@
+import CONFIG from "@lib/constants";
+import OptionItem from "./optionItem";
+import type { OptionsMap } from "@app-types/types";
+
+export default function ResolutionsOptions({ optionsState }: { optionsState: OptionsMap }) {
+    return (
+        <div className="p-3">
+            <div className="mb-2 text-sm text-zinc-400">Select which resolutions to display:</div>
+            <div className="grid grid-cols-3 gap-2.5">
+                {CONFIG.optionIDs.map((option) => {
+                    return <OptionItem key={option} option={option} optionsState={optionsState} />;
+                })}
+            </div>
+        </div>
+    );
+}

--- a/src/pages/options/resolutionsOptions.tsx
+++ b/src/pages/options/resolutionsOptions.tsx
@@ -1,5 +1,5 @@
 import CONFIG from "@lib/constants";
-import OptionItem from "./optionItem";
+import OptionItem from "@pages/options/optionItem";
 import type { OptionsMap } from "@app-types/types";
 
 export default function ResolutionsOptions({ optionsState }: { optionsState: OptionsMap }) {

--- a/src/pages/options/toasterSettings.tsx
+++ b/src/pages/options/toasterSettings.tsx
@@ -1,58 +1,34 @@
-import { getFromSyncCache, setToSyncCache } from "@lib/cache";
+import type { OptionsMap } from "@app-types/types";
+import useOptions from "@hooks/useOptions";
 import { cn } from "@lib/cn";
 import CONFIG from "@lib/constants";
-import { useEffect, useState } from "react";
 
-export default function ToasterSettings() {
-    const [toasterThreshold, setToasterThreshold] = useState<number>(
-        CONFIG.DEFAULT_TOASTER_THRESHOLD,
-    );
-    const [thresholdUnit, setThresholdUnit] = useState<"mbPerMinute" | "mbPerHour">(
-        CONFIG.DEFAULT_TOASTER_THRESHOLD_UNIT,
-    );
+export default function ToasterSettings({ optionsState }: { optionsState: OptionsMap }) {
+    const toasterThreshold = optionsState.toasterThreshold ?? CONFIG.DEFAULT_TOASTER_THRESHOLD;
 
-    const [toasterEnabled, setToasterEnabled] = useState<boolean>(CONFIG.DEFAULT_TOASTER_ENABLED);
-    useEffect(() => {
-        void (async () => {
-            const toasterThreshold =
-                (await getFromSyncCache("toasterThreshold")) ?? CONFIG.DEFAULT_TOASTER_THRESHOLD;
-            const toasterThresholdUnit =
-                ((await getFromSyncCache("toasterThresholdUnit")) as
-                    "mbPerMinute" | "mbPerHour" | undefined) ??
-                CONFIG.DEFAULT_TOASTER_THRESHOLD_UNIT;
+    const thresholdUnit =
+        optionsState.toasterThresholdUnit ?? CONFIG.DEFAULT_TOASTER_THRESHOLD_UNIT;
 
-            if (typeof toasterThreshold === "number") {
-                setToasterThreshold(toasterThreshold);
-            }
-            setThresholdUnit(toasterThresholdUnit);
-        })();
-    }, []);
+    const isToasterEnabled = optionsState.toasterEnabled ?? CONFIG.DEFAULT_TOASTER_ENABLED;
 
-    useEffect(() => {
-        void (async () => {
-            const isToasterEnabled =
-                (await getFromSyncCache("toasterEnabled")) ?? CONFIG.DEFAULT_TOASTER_ENABLED;
-            if (typeof isToasterEnabled === "boolean") {
-                setToasterEnabled(isToasterEnabled);
-            }
-        })();
-    }, []);
+    const { updateOptionsMutation } = useOptions();
+    const { mutate: updateOptions } = updateOptionsMutation;
 
     return (
         <div className="p-3.5">
             <div className="mb-2 text-xs font-semibold tracking-wide text-zinc-400 uppercase">
                 Data Usage Alert
             </div>
-            <div className="mb-2 text-xs text-zinc-400">
+            <p className="mb-2 text-xs text-zinc-400">
                 Show a warning when internet usage gets too high.
-            </div>
+            </p>
             <div
                 className={cn(
                     "rounded-md border border-transparent bg-white/4 px-2.5 py-2 transition-colors duration-300",
-                    !toasterEnabled && "bg-white/1 opacity-80",
+                    !isToasterEnabled && "bg-white/1 opacity-80",
                 )}
             >
-                <div className="flex items-center justify-between rounded-md border border-transparent bg-white/4 px-4 py-2 transition-all duration-300 hover:border-white/15 hover:bg-white/8">
+                <section className="flex items-center justify-between rounded-md border border-transparent bg-white/4 px-4 py-2 transition-all duration-300 hover:border-white/15 hover:bg-white/8">
                     <label
                         className="cursor-pointer text-xs font-medium text-white"
                         htmlFor="toasterThresholdToggle"
@@ -62,19 +38,17 @@ export default function ToasterSettings() {
                     <input
                         type="checkbox"
                         id="toasterThresholdToggle"
-                        checked={toasterEnabled}
+                        checked={isToasterEnabled}
                         onChange={(event) => {
                             const { checked } = event.target;
-                            void setToSyncCache({
-                                toasterEnabled: checked,
-                            }).then(() => setToasterEnabled(checked));
+                            updateOptions({ toasterEnabled: checked });
                         }}
                     />
-                </div>
-                <div
+                </section>
+                <section
                     className={cn(
                         "mt-3 rounded-lg border border-white/5 bg-white/3 p-2.5 transition-all duration-300 ease-in-out hover:border-white/10 hover:bg-white/6",
-                        !toasterEnabled && "bg-white/1 opacity-60",
+                        !isToasterEnabled && "bg-white/1 opacity-60",
                     )}
                 >
                     <div className="flex items-center gap-2.5">
@@ -93,55 +67,88 @@ export default function ToasterSettings() {
                             onChange={(event) => {
                                 const value = Number(event.target.value);
                                 if (value < 1 || value > 10_000 || Number.isNaN(value)) return;
-                                void setToSyncCache({
+                                updateOptions({
                                     toasterThreshold: value,
-                                }).then(() => setToasterThreshold(value));
+                                });
                             }}
-                            disabled={!toasterEnabled}
+                            disabled={!isToasterEnabled}
                         />
                     </div>
-                    <div className="flex items-center justify-around pt-2.5">
-                        <input
-                            type="radio"
+                    <div className="flex items-center justify-around gap-6 pt-2.5">
+                        <RadioOption
                             id="toasterThresholdType1"
                             name="toasterThresholdType"
                             value="mbPerHour"
-                            onChange={() => {
-                                void setToSyncCache({
-                                    toasterThresholdUnit: "mbPerHour",
-                                }).then(() => setThresholdUnit("mbPerHour"));
-                            }}
                             checked={thresholdUnit === "mbPerHour"}
-                            disabled={!toasterEnabled}
-                        />
-                        <label
-                            htmlFor="toasterThresholdType1"
-                            className="cursor-pointer text-xs font-medium text-zinc-300"
+                            disabled={!isToasterEnabled}
+                            onChange={() => {
+                                updateOptions({
+                                    toasterThresholdUnit: "mbPerHour",
+                                });
+                            }}
                         >
                             MB/hour
-                        </label>
-                        <input
-                            type="radio"
+                        </RadioOption>
+
+                        <RadioOption
                             id="toasterThresholdType2"
                             name="toasterThresholdType"
                             value="mbPerMinute"
-                            onChange={() => {
-                                void setToSyncCache({
-                                    toasterThresholdUnit: "mbPerMinute",
-                                }).then(() => setThresholdUnit("mbPerMinute"));
-                            }}
                             checked={thresholdUnit === "mbPerMinute"}
-                            disabled={!toasterEnabled}
-                        />
-                        <label
-                            htmlFor="toasterThresholdType2"
-                            className="cursor-pointer text-xs font-medium text-zinc-300"
+                            disabled={!isToasterEnabled}
+                            onChange={() => {
+                                updateOptions({
+                                    toasterThresholdUnit: "mbPerMinute",
+                                });
+                            }}
                         >
                             MB/minute
-                        </label>
+                        </RadioOption>
                     </div>
-                </div>
+                </section>
             </div>
         </div>
+    );
+}
+
+interface RadioOptionProps {
+    id: string;
+    name: string;
+    value: string;
+    checked: boolean;
+    disabled?: boolean;
+    onChange: () => void;
+    children: React.ReactNode;
+}
+
+function RadioOption({
+    id,
+    name,
+    value,
+    checked,
+    disabled = false,
+    onChange,
+    children,
+}: RadioOptionProps) {
+    return (
+        <label
+            htmlFor={id}
+            className={cn(
+                "flex cursor-pointer items-center gap-2 text-xs font-medium text-zinc-300",
+                disabled && "cursor-not-allowed text-zinc-500",
+            )}
+        >
+            <input
+                type="radio"
+                id={id}
+                name={name}
+                value={value}
+                checked={checked}
+                onChange={onChange}
+                disabled={disabled}
+                className="cursor-pointer accent-sky-400"
+            />
+            {children}
+        </label>
     );
 }

--- a/src/pages/options/toasterSettings.tsx
+++ b/src/pages/options/toasterSettings.tsx
@@ -1,7 +1,7 @@
 import { getFromSyncCache, setToSyncCache } from "@lib/cache";
+import { cn } from "@lib/cn";
 import CONFIG from "@lib/constants";
 import { useEffect, useState } from "react";
-import clsx from "clsx";
 
 export default function ToasterSettings() {
     const [toasterThreshold, setToasterThreshold] = useState<number>(
@@ -47,7 +47,7 @@ export default function ToasterSettings() {
                 Show a warning when internet usage gets too high.
             </div>
             <div
-                className={clsx(
+                className={cn(
                     "rounded-md border border-transparent bg-white/4 px-2.5 py-2 transition-colors duration-300",
                     !toasterEnabled && "bg-white/1 opacity-80",
                 )}
@@ -72,7 +72,7 @@ export default function ToasterSettings() {
                     />
                 </div>
                 <div
-                    className={clsx(
+                    className={cn(
                         "mt-3 rounded-lg border border-white/5 bg-white/3 p-2.5 transition-all duration-300 ease-in-out hover:border-white/10 hover:bg-white/6",
                         !toasterEnabled && "bg-white/1 opacity-60",
                     )}

--- a/src/pages/popup/platforms/formatItem.tsx
+++ b/src/pages/popup/platforms/formatItem.tsx
@@ -5,7 +5,7 @@ import {
     totalSizeVideoDisplay,
 } from "@lib/formatting";
 import type { StreamInfo, YoutubeData, YoutubeVideoFormat } from "@app-types/types";
-import clsx from "clsx";
+import { cn } from "@lib/cn";
 
 interface Props {
     item: YoutubeData["formats"][number] | StreamInfo;
@@ -37,7 +37,7 @@ export default function FormatItem({
 
     return (
         <div
-            className={clsx(
+            className={cn(
                 "flex cursor-pointer items-center justify-between rounded-lg border border-teal-950 px-3 py-2.5",
                 { "bg-red-800/80 hover:border-red-600": resolution === currentQuality },
                 { "bg-stone-800 hover:border-teal-800": resolution !== currentQuality },

--- a/src/pages/popup/platforms/kick/kickFormats.tsx
+++ b/src/pages/popup/platforms/kick/kickFormats.tsx
@@ -4,8 +4,8 @@ import useTab from "@hooks/useTab";
 import FormatItem from "../formatItem";
 
 export default function KickFormats({ data }: { data: KickData }) {
-    const { tabId, tabUrl } = useTab();
-    const { currentQuality } = useCurrentQuality(tabId, tabUrl);
+    const { data: tabData } = useTab();
+    const { currentQuality } = useCurrentQuality(tabData?.tabId);
 
     return data.data.map((item) => {
         return (
@@ -13,7 +13,7 @@ export default function KickFormats({ data }: { data: KickData }) {
                 key={item.resolution}
                 item={item}
                 durationSeconds={data.type === "vod" ? data.durationSeconds : undefined}
-                currentQuality={currentQuality}
+                currentQuality={currentQuality?.quality}
                 isLive={data.type === "live"}
             />
         );

--- a/src/pages/popup/platforms/kick/kickFormats.tsx
+++ b/src/pages/popup/platforms/kick/kickFormats.tsx
@@ -1,7 +1,7 @@
 import type { KickData } from "@app-types/types";
 import useCurrentQuality from "@hooks/useCurrentQuality";
 import useTab from "@hooks/useTab";
-import FormatItem from "../formatItem";
+import FormatItem from "@pages/popup/platforms/formatItem";
 
 export default function KickFormats({ data }: { data: KickData }) {
     const { data: tabData } = useTab();

--- a/src/pages/popup/platforms/kick/kickView.tsx
+++ b/src/pages/popup/platforms/kick/kickView.tsx
@@ -1,25 +1,33 @@
 import { useKickData } from "@/hooks/useKickData";
-import Header from "../../header";
+import Header from "@pages/popup/header";
 import InfoCard from "@components/infoCard";
 import KickFormats from "./kickFormats";
 import Spinner from "@components/spinner";
+import { PopupViewContainer } from "@pages/popup/popupViewContainer";
 
 export function KickView({ tabUrl, tabId }: { tabUrl: string; tabId: number }) {
-    const { data, error, message, isLoading, createdAt } = useKickData(tabUrl, tabId);
+    const { query, isKickRelated } = useKickData(tabUrl, tabId);
+    const { isPending, isError, data, error } = query;
 
-    if (isLoading) return <Spinner />;
-    if (error) throw error;
+    if (!isKickRelated) {
+        return (
+            <>
+                <Header />
+                <PopupViewContainer>
+                    <InfoCard message="Open a Kick Stream" />
+                </PopupViewContainer>
+            </>
+        );
+    }
+
+    if (isPending) return <Spinner />;
+    if (isError) throw error;
 
     return (
         <>
-            <Header
-                data={data ? { platform: "kick", data, cacheCreatedAt: createdAt } : undefined}
-            />
+            <Header data={{ platform: "kick", data: data.data, cacheCreatedAt: data.createdAt }} />
 
-            <div className="flex flex-col gap-2 px-3 py-1.5 text-xs text-zinc-400">
-                {message && <InfoCard message={message} />}
-                {data && <KickFormats data={data} />}
-            </div>
+            <PopupViewContainer>{<KickFormats data={data.data} />}</PopupViewContainer>
         </>
     );
 }

--- a/src/pages/popup/platforms/kick/kickView.tsx
+++ b/src/pages/popup/platforms/kick/kickView.tsx
@@ -1,7 +1,7 @@
 import { useKickData } from "@/hooks/useKickData";
 import Header from "@pages/popup/header";
 import InfoCard from "@components/infoCard";
-import KickFormats from "./kickFormats";
+import KickFormats from "@pages/popup/platforms/kick/kickFormats";
 import Spinner from "@components/spinner";
 import { PopupViewContainer } from "@pages/popup/popupViewContainer";
 

--- a/src/pages/popup/platforms/twitch/twitchFormats.tsx
+++ b/src/pages/popup/platforms/twitch/twitchFormats.tsx
@@ -4,8 +4,8 @@ import useTab from "@hooks/useTab";
 import FormatItem from "../formatItem";
 
 export default function TwitchFormats({ data }: { data: TwitchData }) {
-    const { tabId, tabUrl } = useTab();
-    const { currentQuality } = useCurrentQuality(tabId, tabUrl);
+    const { data: tabData } = useTab();
+    const { currentQuality } = useCurrentQuality(tabData?.tabId);
 
     return data.data.map((item) => {
         return (
@@ -13,7 +13,7 @@ export default function TwitchFormats({ data }: { data: TwitchData }) {
                 key={item.resolution}
                 item={item}
                 durationSeconds={data.type === "vod" ? data.durationSeconds : undefined}
-                currentQuality={currentQuality}
+                currentQuality={currentQuality?.quality}
                 isLive={data.type === "live"}
             />
         );

--- a/src/pages/popup/platforms/twitch/twitchFormats.tsx
+++ b/src/pages/popup/platforms/twitch/twitchFormats.tsx
@@ -1,7 +1,7 @@
 import type { TwitchData } from "@app-types/types";
 import useCurrentQuality from "@hooks/useCurrentQuality";
 import useTab from "@hooks/useTab";
-import FormatItem from "../formatItem";
+import FormatItem from "@pages/popup/platforms/formatItem";
 
 export default function TwitchFormats({ data }: { data: TwitchData }) {
     const { data: tabData } = useTab();

--- a/src/pages/popup/platforms/twitch/twitchView.tsx
+++ b/src/pages/popup/platforms/twitch/twitchView.tsx
@@ -2,7 +2,7 @@ import Header from "@pages/popup/header";
 import InfoCard from "@components/infoCard";
 import Spinner from "@components/spinner";
 import { useTwitchData } from "@/hooks/useTwitchData";
-import TwitchFormats from "./twitchFormats";
+import TwitchFormats from "@pages/popup/platforms/twitch/twitchFormats";
 import { PopupViewContainer } from "@pages/popup/popupViewContainer";
 
 export function TwitchView({ tabUrl }: { tabUrl: string }) {

--- a/src/pages/popup/platforms/twitch/twitchView.tsx
+++ b/src/pages/popup/platforms/twitch/twitchView.tsx
@@ -1,25 +1,41 @@
-import Header from "../../header";
+import Header from "@pages/popup/header";
 import InfoCard from "@components/infoCard";
 import Spinner from "@components/spinner";
 import { useTwitchData } from "@/hooks/useTwitchData";
 import TwitchFormats from "./twitchFormats";
+import { PopupViewContainer } from "@pages/popup/popupViewContainer";
 
 export function TwitchView({ tabUrl }: { tabUrl: string }) {
-    const { data, error, message, isLoading, createdAt } = useTwitchData(tabUrl);
+    const { query, isTwitchRelated } = useTwitchData(tabUrl);
+    const { isPending, isError, data, error } = query;
 
-    if (isLoading) return <Spinner />;
-    if (error) throw error;
+    if (!isTwitchRelated) {
+        return (
+            <>
+                <Header />
+                <PopupViewContainer>
+                    <InfoCard message="Open a Twitch stream or VOD" />
+                </PopupViewContainer>
+            </>
+        );
+    }
+
+    if (isPending) return <Spinner />;
+    if (isError) throw error;
 
     return (
         <>
             <Header
-                data={data ? { platform: "twitch", data, cacheCreatedAt: createdAt } : undefined}
+                data={{
+                    platform: "twitch",
+                    data: data.data,
+                    cacheCreatedAt: data.createdAt,
+                }}
             />
 
-            <div className="flex flex-col gap-2 px-3 py-1.5 text-xs text-zinc-400">
-                {message && <InfoCard message={message} />}
-                {data && <TwitchFormats data={data} />}
-            </div>
+            <PopupViewContainer>
+                <TwitchFormats data={data.data} />
+            </PopupViewContainer>
         </>
     );
 }

--- a/src/pages/popup/platforms/youtube/youtubeFormats.tsx
+++ b/src/pages/popup/platforms/youtube/youtubeFormats.tsx
@@ -2,7 +2,7 @@ import type { OptionsMap, YoutubeData } from "@app-types/types";
 import CONFIG from "@lib/constants";
 import useOptions from "@hooks/useOptions";
 import useCurrentQuality from "@hooks/useCurrentQuality";
-import FormatItem from "../formatItem";
+import FormatItem from "@pages/popup/platforms/formatItem";
 import InfoCard from "@components/infoCard";
 
 function getEnabledOptions(optionsState: OptionsMap | undefined) {

--- a/src/pages/popup/platforms/youtube/youtubeFormats.tsx
+++ b/src/pages/popup/platforms/youtube/youtubeFormats.tsx
@@ -5,7 +5,7 @@ import useCurrentQuality from "@hooks/useCurrentQuality";
 import FormatItem from "../formatItem";
 import InfoCard from "@components/infoCard";
 
-function getEnabledOptions(optionsState: OptionsMap | null) {
+function getEnabledOptions(optionsState: OptionsMap | undefined) {
     const qualityIds = optionsState?.["qualityIds"] ?? {};
     return CONFIG.optionIDs.filter((option) => qualityIds[option] ?? true);
 }
@@ -13,16 +13,16 @@ function getEnabledOptions(optionsState: OptionsMap | null) {
 export default function YoutubeFormats({
     data,
     tabId,
-    tabUrl,
 }: {
     data: YoutubeData;
     tabId: number | undefined;
-    tabUrl: string | undefined;
 }) {
-    const { currentQuality } = useCurrentQuality(tabId, tabUrl);
+    const { currentQuality } = useCurrentQuality(tabId);
 
-    const { optionsState, error: optionsError } = useOptions();
-    if (optionsError) throw optionsError;
+    const { query } = useOptions();
+    const { data: optionsState, isError, error, isPending } = query;
+    if (isError) throw error;
+    if (isPending) return null;
 
     const enabledOptions = getEnabledOptions(optionsState);
 
@@ -40,7 +40,7 @@ export default function YoutubeFormats({
                     <FormatItem
                         key={item.resolution}
                         item={item}
-                        currentQuality={currentQuality}
+                        currentQuality={currentQuality?.quality}
                         isShorts={false}
                         isLive={true}
                     />
@@ -58,7 +58,7 @@ export default function YoutubeFormats({
                     item={item}
                     isLive={false}
                     isShorts={data.isShorts || false}
-                    currentQuality={currentQuality}
+                    currentQuality={currentQuality?.quality}
                     durationSeconds={data.durationSeconds}
                 />
             );

--- a/src/pages/popup/platforms/youtube/youtubeView.tsx
+++ b/src/pages/popup/platforms/youtube/youtubeView.tsx
@@ -1,8 +1,8 @@
 import { useYoutubeData } from "@hooks/useYoutubeData";
-import Header from "../../header";
+import Header from "@pages/popup/header";
 import InfoCard from "@components/infoCard";
-import YoutubeFormats from "./youtubeFormats";
-import PopupUsage from "../../popupUsage";
+import YoutubeFormats from "@pages/popup/platforms/youtube/youtubeFormats";
+import PopupUsage from "@pages/popup/popupUsage";
 import Spinner from "@components/spinner";
 
 export function YoutubeView({ tabUrl, tabId }: { tabUrl: string; tabId: number }) {

--- a/src/pages/popup/platforms/youtube/youtubeView.tsx
+++ b/src/pages/popup/platforms/youtube/youtubeView.tsx
@@ -6,21 +6,33 @@ import PopupUsage from "../../popupUsage";
 import Spinner from "@components/spinner";
 
 export function YoutubeView({ tabUrl, tabId }: { tabUrl: string; tabId: number }) {
-    const { data, error, message, createdAt, isLoading } = useYoutubeData(tabUrl, tabId);
+    const { query, isYoutubeVideo } = useYoutubeData(tabUrl, tabId);
+    const { isPending, isError, data, error } = query;
 
-    if (isLoading) return <Spinner />;
-    if (error) throw error;
+    if (!isYoutubeVideo) {
+        return (
+            <>
+                <Header />
+                <div className="flex flex-col gap-2 px-3 py-1.5 text-xs text-zinc-400">
+                    <PopupUsage />
+                    <InfoCard message="Open a Youtube video" />
+                </div>
+            </>
+        );
+    }
+
+    if (isPending) return <Spinner />;
+    if (isError) throw error;
 
     return (
         <>
             <Header
-                data={data ? { platform: "youtube", data, cacheCreatedAt: createdAt } : undefined}
+                data={{ platform: "youtube", data: data.data, cacheCreatedAt: data.createdAt }}
             />
 
             <div className="flex flex-col gap-2 px-3 py-1.5 text-xs text-zinc-400">
                 <PopupUsage />
-                {message && <InfoCard message={message} />}
-                {data && <YoutubeFormats data={data} tabId={tabId} />}
+                <YoutubeFormats data={data.data} tabId={tabId} />
             </div>
         </>
     );

--- a/src/pages/popup/platforms/youtube/youtubeView.tsx
+++ b/src/pages/popup/platforms/youtube/youtubeView.tsx
@@ -1,4 +1,4 @@
-import { useYoutubeData } from "@/hooks/useYoutubeData";
+import { useYoutubeData } from "@hooks/useYoutubeData";
 import Header from "../../header";
 import InfoCard from "@components/infoCard";
 import YoutubeFormats from "./youtubeFormats";
@@ -18,9 +18,9 @@ export function YoutubeView({ tabUrl, tabId }: { tabUrl: string; tabId: number }
             />
 
             <div className="flex flex-col gap-2 px-3 py-1.5 text-xs text-zinc-400">
-                <PopupUsage tabId={tabId} />
+                <PopupUsage />
                 {message && <InfoCard message={message} />}
-                {data && <YoutubeFormats data={data} tabId={tabId} tabUrl={tabUrl} />}
+                {data && <YoutubeFormats data={data} tabId={tabId} />}
             </div>
         </>
     );

--- a/src/pages/popup/popup.tsx
+++ b/src/pages/popup/popup.tsx
@@ -1,11 +1,11 @@
 import { isYoutubePage, isTwitchPage, isKickPage } from "@lib/utils";
-import Header from "./header";
+import Header from "@pages/popup/header";
 import useTab from "@hooks/useTab";
 import InfoCard from "@components/infoCard";
 import Spinner from "@components/spinner";
-import { YoutubeView } from "./platforms/youtube/youtubeView";
-import { TwitchView } from "./platforms/twitch/twitchView";
-import { KickView } from "./platforms/kick/kickView";
+import { YoutubeView } from "@pages/popup/platforms/youtube/youtubeView";
+import { TwitchView } from "@pages/popup/platforms/twitch/twitchView";
+import { KickView } from "@pages/popup/platforms/kick/kickView";
 
 export default function Popup() {
     const { data: tab, error, isPending, isError } = useTab();

--- a/src/pages/popup/popup.tsx
+++ b/src/pages/popup/popup.tsx
@@ -8,17 +8,16 @@ import { TwitchView } from "./platforms/twitch/twitchView";
 import { KickView } from "./platforms/kick/kickView";
 
 export default function Popup() {
-    const { tabUrl, tabId, error, isLoading } = useTab();
-
-    if (error) throw error;
-
-    if (isLoading) {
+    const { data: tab, error, isPending, isError } = useTab();
+    if (isError) throw error;
+    if (isPending)
         return (
             <div className="flex w-60 items-center justify-center p-4">
                 <Spinner />
             </div>
         );
-    }
+
+    const { tabUrl, tabId } = tab;
 
     // 2. Platform sub-views
     if (tabUrl && tabId) {

--- a/src/pages/popup/popupUsage.tsx
+++ b/src/pages/popup/popupUsage.tsx
@@ -1,32 +1,24 @@
 import { totalSizeVideoDisplay } from "@lib/formatting";
 import { useEffect, useState } from "react";
-import { getTodayUsage, getUsageByDay, getUsageNumber } from "@lib/analyticsUtils";
+import { getTodayUsage, getUsageNumber } from "@lib/analyticsUtils";
+import useUsage from "@hooks/useUsage";
 
-async function getTodaysTotalUsage(tabId: number | undefined) {
-    if (!tabId) return;
-    const usageByDay = await getUsageByDay();
-
-    const totalTodaysUsage = getUsageNumber(getTodayUsage(usageByDay));
-    return totalTodaysUsage;
-}
-
-export default function PopupUsage({ tabId }: { tabId: number | undefined }) {
-    const [todayUsage, setTodayUsage] = useState<number | undefined>();
+export default function PopupUsage() {
+    const [todayUsage, setTodayUsage] = useState<number>();
+    const { query } = useUsage();
+    const { data: usageByDay } = query;
 
     useEffect(() => {
-        const updateUsage = async () => {
-            const total = await getTodaysTotalUsage(tabId);
+        const handleUpdateUsage = () => {
+            const total = usageByDay ? getUsageNumber(getTodayUsage(usageByDay)) : 0;
             setTodayUsage(total);
         };
-        const handleUpdateUsage = () => {
-            void updateUsage();
-        };
 
-        void updateUsage();
+        void handleUpdateUsage();
         chrome.storage.onChanged.addListener(handleUpdateUsage);
 
         return () => chrome.storage.onChanged.removeListener(handleUpdateUsage);
-    }, [tabId]);
+    }, [usageByDay]);
 
     return (
         <>
@@ -34,7 +26,9 @@ export default function PopupUsage({ tabId }: { tabId: number | undefined }) {
                 <div>
                     <button
                         className="flex w-full cursor-pointer items-center justify-between rounded-lg border border-white/12 bg-white/3 px-3 py-2 text-xs font-medium text-zinc-300 hover:bg-white/6"
-                        onClick={() => void chrome.tabs.create({ url: "index.html#/today" })}
+                        onClick={() =>
+                            void chrome.tabs.create({ url: "index.html#/analytics/today" })
+                        }
                     >
                         <span>{"YouTube Usage Today: "}</span>
                         <span>{totalSizeVideoDisplay(todayUsage)}</span>

--- a/src/pages/popup/popupUsage.tsx
+++ b/src/pages/popup/popupUsage.tsx
@@ -1,28 +1,28 @@
 import { totalSizeVideoDisplay } from "@lib/formatting";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { getTodayUsage, getUsageNumber } from "@lib/analyticsUtils";
 import useUsage from "@hooks/useUsage";
+import { useQueryClient } from "@tanstack/react-query";
 
 export default function PopupUsage() {
-    const [todayUsage, setTodayUsage] = useState<number>();
+    const queryClient = useQueryClient();
     const { query } = useUsage();
     const { data: usageByDay } = query;
 
     useEffect(() => {
-        const handleUpdateUsage = () => {
-            const total = usageByDay ? getUsageNumber(getTodayUsage(usageByDay)) : 0;
-            setTodayUsage(total);
+        const handleStorageChange = () => {
+            void queryClient.invalidateQueries({ queryKey: ["usage"] });
         };
 
-        void handleUpdateUsage();
-        chrome.storage.onChanged.addListener(handleUpdateUsage);
+        chrome.storage.onChanged.addListener(handleStorageChange);
+        return () => chrome.storage.onChanged.removeListener(handleStorageChange);
+    }, [queryClient]);
 
-        return () => chrome.storage.onChanged.removeListener(handleUpdateUsage);
-    }, [usageByDay]);
+    const todayUsage = usageByDay ? getUsageNumber(getTodayUsage(usageByDay)) : 0;
 
     return (
         <>
-            {todayUsage !== undefined && (
+            {
                 <div>
                     <button
                         className="flex w-full cursor-pointer items-center justify-between rounded-lg border border-white/12 bg-white/3 px-3 py-2 text-xs font-medium text-zinc-300 hover:bg-white/6"
@@ -34,7 +34,7 @@ export default function PopupUsage() {
                         <span>{totalSizeVideoDisplay(todayUsage)}</span>
                     </button>
                 </div>
-            )}
+            }
         </>
     );
 }

--- a/src/pages/popup/popupViewContainer.tsx
+++ b/src/pages/popup/popupViewContainer.tsx
@@ -1,0 +1,3 @@
+export function PopupViewContainer({ children }: { children: React.ReactNode }) {
+    return <div className="flex flex-col gap-2 px-3 py-1.5 text-xs text-zinc-400">{children}</div>;
+}

--- a/src/resolution.ts
+++ b/src/resolution.ts
@@ -67,15 +67,12 @@ export async function startYoutubeToastTracking(youtubeResponse: YoutubeData) {
 }
 
 async function getToasterThreshold() {
-    return (
-        ((await getFromSyncCache("toasterThreshold")) as number) || CONFIG.DEFAULT_TOASTER_THRESHOLD
-    );
+    return (await getFromSyncCache("toasterThreshold")) || CONFIG.DEFAULT_TOASTER_THRESHOLD;
 }
 
 async function getToasterThresholdUnit() {
     return (
-        ((await getFromSyncCache("toasterThresholdUnit")) as
-            "mbPerMinute" | "mbPerHour" | undefined) || CONFIG.DEFAULT_TOASTER_THRESHOLD_UNIT
+        (await getFromSyncCache("toasterThresholdUnit")) || CONFIG.DEFAULT_TOASTER_THRESHOLD_UNIT
     );
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -69,7 +69,7 @@ export type StorageData<T extends YoutubeData | TwitchData | KickData> = {
 export type OptionsMap = {
     toasterEnabled?: boolean;
     toasterThreshold?: number;
-    toasterThresholdUnit?: string;
+    toasterThresholdUnit?: "mbPerHour" | "mbPerMinute";
     cacheTTL?: number;
     qualityIds?: Record<string, boolean>;
     qualityMenu?: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,6 @@
         "noUncheckedSideEffectImports": true,
         "noUncheckedIndexedAccess": true,
         "paths": {
-            "@/*": ["./src/*"],
             "@components/*": ["./src/components/*"],
             "@styles/*": ["./src/styles/*"],
             "@pages/*": ["./src/pages/*"],
@@ -33,7 +32,8 @@
             "@assets/*": ["./src/assets/*"],
             "@hooks/*": ["./src/hooks/*"],
             "@app-types/*": ["./src/types/*"],
-            "@layouts/*": ["./src/layouts/*"]
+            "@layouts/*": ["./src/layouts/*"],
+            "@/*": ["./src/*"]
         }
     },
     "include": ["./src", "./src/types", "vite.config.ts"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,6 @@ export default defineConfig(({ mode }) => ({
     },
     resolve: {
         alias: {
-            "@": path.resolve(__dirname, "src"),
             "@components": path.resolve(__dirname, "src/components"),
             "@styles": path.resolve(__dirname, "src/styles"),
             "@pages": path.resolve(__dirname, "src/pages"),
@@ -26,6 +25,7 @@ export default defineConfig(({ mode }) => ({
             "@hooks": path.resolve(__dirname, "src/hooks"),
             "@app-types": path.resolve(__dirname, "src/types"),
             "@layouts": path.resolve(__dirname, "src/layouts"),
+            "@": path.resolve(__dirname, "src"),
         },
     },
     plugins: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added TanStack Query runtime and ESLint support.
- Replaced effect-based data fetching and local state with queries and mutations.
- Added shared `QueryClientProvider` configuration.
- Updated analytics, options, popup, YouTube, Twitch, and Kick views to consume query state.
- Added explicit loading, error, pending, and empty-data handling.
- Centralized options and cache updates through query mutations and invalidation.
- Improved cache typing and handling of missing values.
- Added the shared `cn` utility for Tailwind class merging.
- Improved usage tracking and badge handling when analytics data is unavailable.
- Tightened `OptionsMap.toasterThresholdUnit` typing.
- Updated path aliases and component interfaces to support the refactoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->