### PR TITLE
general fixes

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -5,8 +5,9 @@ import {
     extractVideoTag,
     isKickPage,
     isKickVod,
+    isKickStream,
     isTwitchPage,
-    isTwitchVod,
+    isTwitchLive,
     isYoutubePage,
     delay,
 } from "@lib/utils";
@@ -58,7 +59,7 @@ async function handlePageNavigation() {
                 await startYoutubeToastTracking(youtubeResponse);
             }
         } else if (isTwitchPage(url)) {
-            const isLive = !isTwitchVod(url);
+            const isLive = isTwitchLive(url);
             const tag = isLive ? extractChannelName(url) : extractTwitchVodId(url);
 
             stopResolutionTracking();
@@ -72,7 +73,7 @@ async function handlePageNavigation() {
         } else if (isKickPage(url)) {
             stopResolutionTracking();
             const isToasterEnable = await isToasterEnabled();
-            if (isToasterEnable) {
+            if (isToasterEnable && (isKickStream(url) || isKickVod(url))) {
                 const kickData = await initKick(false);
                 if (!kickData.success) {
                     throw new Error(kickData.message || "Failed to initialize Kick data");

--- a/src/hooks/useTwitchData.ts
+++ b/src/hooks/useTwitchData.ts
@@ -1,16 +1,23 @@
-import { extractChannelName, extractTwitchVodId, isTwitchPage, isTwitchVod } from "@lib/utils";
+import {
+    extractChannelName,
+    extractTwitchVodId,
+    isTwitchLive,
+    isTwitchPage,
+    isTwitchVod,
+} from "@lib/utils";
 import { sendMessageToBackground } from "@/runtime";
 import { useQuery } from "@tanstack/react-query";
 
 export function useTwitchData(tabUrl: string) {
-    const isTwitchRelated = isTwitchPage(tabUrl);
+    const isTwitchRelated = isTwitchPage(tabUrl) && (isTwitchLive(tabUrl) || isTwitchVod(tabUrl));
     const query = useQuery({
         queryKey: ["twitch", tabUrl],
         queryFn: async () => {
+            // The page is a Twitch Video (Not a live stream)
             if (isTwitchVod(tabUrl)) {
                 const vodId = extractTwitchVodId(tabUrl);
                 if (!vodId) {
-                    throw new Error("Open a Twitch stream or VOD");
+                    throw new Error("Open a Twitch stream or video");
                 }
 
                 const response = await sendMessageToBackground({
@@ -24,9 +31,10 @@ export function useTwitchData(tabUrl: string) {
                     createdAt: response.createdAt,
                 };
             }
+            // The page is a Twitch Live Stream
             const channelName = extractChannelName(tabUrl);
             if (!channelName) {
-                throw new Error("Open a Twitch stream");
+                throw new Error("Open a Twitch stream or video");
             }
 
             const response = await sendMessageToBackground({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -32,18 +32,7 @@ export function isTwitchPage(url: string): boolean {
             parsedUrl.hostname === "www.twitch.com" ||
             parsedUrl.hostname === "twitch.com";
 
-        if (!isTwitchHost) return false;
-
-        const pathSegments = parsedUrl.pathname.split("/").filter(Boolean);
-        if (pathSegments.length === 0) return false; // No path segments, not a valid Twitch URL
-
-        // Check for Invalid VOD URL (e.g., twitch.tv/videos without vodId)
-        if (pathSegments.length === 1 && pathSegments[0] === "videos") return false;
-        // Check for channel URL (e.g., twitch.tv/channelName)
-        if (pathSegments.length === 1) return true;
-
-        // Check for VOD URL (e.g., twitch.tv/videos/vodId)
-        return pathSegments.length === 2 && pathSegments[0] === "videos";
+        return isTwitchHost;
     } catch {
         return false;
     }
@@ -55,6 +44,33 @@ export function isTwitchVod(url: string): boolean {
         const parsedUrl = new URL(url);
         const pathname = parsedUrl.pathname.split("/").filter(Boolean);
         return pathname.length === 2 && pathname[0] === "videos" && /^[0-9]+$/.test(pathname[1]!);
+    } catch {
+        return false;
+    }
+}
+
+export function isTwitchLive(url: string): boolean {
+    if (!isTwitchPage(url)) return false;
+    try {
+        const parsedUrl = new URL(url);
+        const pathSegments = parsedUrl.pathname.split("/").filter(Boolean);
+        if (pathSegments.length !== 1) return false;
+
+        const notStreamPath = new Set([
+            "videos",
+            "directory",
+            "settings",
+            "downloads",
+            "search",
+            "store",
+            "turbo",
+            "jobs",
+            "p",
+            "about",
+            "privacy",
+            "terms",
+        ]);
+        return !notStreamPath.has(pathSegments[0]!); // Assuming twitch.tv/channelName format for streams
     } catch {
         return false;
     }

--- a/src/pages/popup/header.tsx
+++ b/src/pages/popup/header.tsx
@@ -90,7 +90,12 @@ export default function Header({ data }: Props) {
                 <div className="truncate text-sm font-semibold" title={title}>
                     {title}
                 </div>
-                {isLive && <span className="text-sm font-medium text-red-500">Live</span>}
+                {isLive && (
+                    <div className="flex items-center gap-1">
+                        <span className="size-2 animate-pulse rounded-full bg-red-600"></span>
+                        <span className="animate-pulse text-sm font-bold text-red-500">Live</span>
+                    </div>
+                )}
                 {duration && (
                     <span className="shrink-0 text-xs font-medium text-zinc-400">{duration}</span>
                 )}

--- a/src/pages/popup/platforms/kick/kickView.tsx
+++ b/src/pages/popup/platforms/kick/kickView.tsx
@@ -20,7 +20,13 @@ export function KickView({ tabUrl, tabId }: { tabUrl: string; tabId: number }) {
         );
     }
 
-    if (isPending) return <Spinner />;
+    if (isPending)
+        return (
+            <>
+                <Header />
+                <Spinner />
+            </>
+        );
     if (isError) throw error;
 
     return (

--- a/src/pages/popup/platforms/kick/kickView.tsx
+++ b/src/pages/popup/platforms/kick/kickView.tsx
@@ -14,7 +14,7 @@ export function KickView({ tabUrl, tabId }: { tabUrl: string; tabId: number }) {
             <>
                 <Header />
                 <PopupViewContainer>
-                    <InfoCard message="Open a Kick Stream" />
+                    <InfoCard message="Open a Kick Stream or Video" />
                 </PopupViewContainer>
             </>
         );

--- a/src/pages/popup/platforms/twitch/twitchView.tsx
+++ b/src/pages/popup/platforms/twitch/twitchView.tsx
@@ -14,7 +14,7 @@ export function TwitchView({ tabUrl }: { tabUrl: string }) {
             <>
                 <Header />
                 <PopupViewContainer>
-                    <InfoCard message="Open a Twitch stream or VOD" />
+                    <InfoCard message="Open a Twitch stream or video" />
                 </PopupViewContainer>
             </>
         );

--- a/src/pages/popup/platforms/twitch/twitchView.tsx
+++ b/src/pages/popup/platforms/twitch/twitchView.tsx
@@ -20,7 +20,13 @@ export function TwitchView({ tabUrl }: { tabUrl: string }) {
         );
     }
 
-    if (isPending) return <Spinner />;
+    if (isPending)
+        return (
+            <>
+                <Header />
+                <Spinner />
+            </>
+        );
     if (isError) throw error;
 
     return (

--- a/src/pages/popup/platforms/youtube/youtubeView.tsx
+++ b/src/pages/popup/platforms/youtube/youtubeView.tsx
@@ -22,7 +22,13 @@ export function YoutubeView({ tabUrl, tabId }: { tabUrl: string; tabId: number }
         );
     }
 
-    if (isPending) return <Spinner />;
+    if (isPending)
+        return (
+            <>
+                <Header />
+                <Spinner />
+            </>
+        );
     if (isError) throw error;
 
     const { data: youtubeData, createdAt } = data;

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -4,6 +4,7 @@ import {
     extractVideoTag,
     fetchAndRetry,
     isTwitchPage,
+    isTwitchLive,
     isTwitchVod,
     extractTwitchVodId,
     extractChannelName,
@@ -66,10 +67,36 @@ describe("isTwitchPage", () => {
         expect(isTwitchPage("https://www.twitch.com/somechannel")).toBe(true);
     });
     test("should return false for twitch.com/videos", () => {
-        expect(isTwitchPage("https://www.twitch.com/videos")).toBe(false);
+        expect(isTwitchPage("https://www.twitch.com/videos")).toBe(true);
     });
-    test("should return false for a URL with a different path than videos", () => {
-        expect(isTwitchPage("https://www.twitch.tv/live/somechannel")).toBe(false);
+    test("should return true for a URL with a different path than videos", () => {
+        expect(isTwitchPage("https://www.twitch.tv/live/somechannel")).toBe(true);
+    });
+});
+
+describe("isTwitchLive", () => {
+    test("should return true for a live channel URL", () => {
+        expect(isTwitchLive("https://www.twitch.tv/raidbullys")).toBe(true);
+    });
+
+    test("should return false for a VOD URL", () => {
+        expect(isTwitchLive("https://www.twitch.tv/videos/2848875813")).toBe(false);
+    });
+
+    test("should return false for the bare videos path", () => {
+        expect(isTwitchLive("https://www.twitch.tv/videos")).toBe(false);
+    });
+
+    test("should return false for non-stream paths like directory", () => {
+        expect(isTwitchLive("https://www.twitch.tv/directory")).toBe(false);
+    });
+
+    test("should return false for multi-segment paths", () => {
+        expect(isTwitchLive("https://www.twitch.tv/somechannel/about")).toBe(false);
+    });
+
+    test("should return false for a non-Twitch URL", () => {
+        expect(isTwitchLive("https://www.example.com/somechannel")).toBe(false);
     });
 });
 


### PR DESCRIPTION
- **Fix Twitch live detection flow and align Kick content-script guard**
- **Added header with each spinner**
- **Added an animation pulse to the Live text in the header**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fix Twitch live-page detection with the new `isTwitchLive` utility.
- Restrict Kick polling to stream and VOD pages.
- Add headers to Twitch, Kick, and YouTube spinner states.
- Add a pulsing red dot and `Live` label to the popup header.
- Update Twitch utility and page-detection tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->