### PR TITLE
Implemented Import and Export buttons in dashboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.3.4
-        version: 12.3.4
       pnpm:
         specifier: 12.3.4
         version: 12.3.4
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.3.4':
-    resolution: {integrity: sha512-Rq7JokWAyYF9IFfn8zofB/q2AgnZlmoMuH5fMHB2+Ta61I9aD7sNm+woZpx6iH+5vb38chdSoYRvOtSqlH72YQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.3.4:
     resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.3.4':
     optional: true
-
-  '@pnpm/exe@12.3.4':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.3.4
-      '@pnpm/exe.darwin-x64': 12.3.4
-      '@pnpm/exe.linux-arm64': 12.3.4
-      '@pnpm/exe.linux-arm64-musl': 12.3.4
-      '@pnpm/exe.linux-x64': 12.3.4
-      '@pnpm/exe.linux-x64-musl': 12.3.4
-      '@pnpm/exe.win32-arm64': 12.3.4
-      '@pnpm/exe.win32-x64': 12.3.4
 
   pnpm@12.3.4:
     optionalDependencies:

--- a/src/components/alertDestructive.tsx
+++ b/src/components/alertDestructive.tsx
@@ -1,22 +1,29 @@
 import { AlertCircleIcon, X } from "lucide-react";
 
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { useState } from "react";
 import { Button } from "./ui/button";
 
-export function AlertDestructive({ title, description }: { title: string; description?: string }) {
-    const [close, setClose] = useState(false);
-    if (close) return;
+export function AlertDestructive({
+    title,
+    description,
+    onClose,
+}: {
+    title: string;
+    description?: string;
+    onClose?: () => void;
+}) {
     return (
-        <Alert variant="destructive" className="max-w-sm">
-            <AlertCircleIcon />
-            <AlertTitle>{title}</AlertTitle>
-            <AlertAction>
-                <Button variant="link" onClick={() => setClose(true)}>
-                    <X />
-                </Button>
-            </AlertAction>
-            {description && <AlertDescription>{description}</AlertDescription>}
-        </Alert>
+        <div className="fixed top-1/20 right-1/20 z-50 flex items-center justify-center px-4">
+            <Alert variant="destructive" className="w-full/2">
+                <AlertCircleIcon />
+                <AlertTitle className="text-base">{title}</AlertTitle>
+                <AlertAction>
+                    <Button variant="link" onClick={onClose} size="icon-xs">
+                        <X />
+                    </Button>
+                </AlertAction>
+                {description && <AlertDescription>{description}</AlertDescription>}
+            </Alert>
+        </div>
     );
 }

--- a/src/components/alertDestructive.tsx
+++ b/src/components/alertDestructive.tsx
@@ -1,12 +1,21 @@
-import { AlertCircleIcon } from "lucide-react";
+import { AlertCircleIcon, X } from "lucide-react";
 
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useState } from "react";
+import { Button } from "./ui/button";
 
 export function AlertDestructive({ title, description }: { title: string; description?: string }) {
+    const [close, setClose] = useState(false);
+    if (close) return;
     return (
-        <Alert variant="destructive" className="max-w-md">
+        <Alert variant="destructive" className="max-w-sm">
             <AlertCircleIcon />
             <AlertTitle>{title}</AlertTitle>
+            <AlertAction>
+                <Button variant="link" onClick={() => setClose(true)}>
+                    <X />
+                </Button>
+            </AlertAction>
             {description && <AlertDescription>{description}</AlertDescription>}
         </Alert>
     );

--- a/src/components/alertDestructive.tsx
+++ b/src/components/alertDestructive.tsx
@@ -1,0 +1,13 @@
+import { AlertCircleIcon } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+export function AlertDestructive({ title, description }: { title: string; description?: string }) {
+    return (
+        <Alert variant="destructive" className="max-w-md">
+            <AlertCircleIcon />
+            <AlertTitle>{title}</AlertTitle>
+            {description && <AlertDescription>{description}</AlertDescription>}
+        </Alert>
+    );
+}

--- a/src/components/alertDialogBasic.tsx
+++ b/src/components/alertDialogBasic.tsx
@@ -15,20 +15,23 @@ export function AlertDialogBasic({
     descriptionText,
     buttonText,
     disabled,
+    variant = "outline",
     className,
     onConfirm,
 }: {
     descriptionText: string;
     buttonText: string;
-    disabled: boolean;
+    disabled?: boolean;
     className?: string;
+    variant?:
+        "link" | "default" | "outline" | "secondary" | "ghost" | "destructive" | null | undefined;
     onConfirm: () => void;
 }) {
     return (
         <AlertDialog>
             <AlertDialogTrigger
                 render={
-                    <Button variant="outline" className={className} disabled={disabled}>
+                    <Button variant={variant} className={className} disabled={disabled}>
                         {buttonText}
                     </Button>
                 }

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
+
+const alertVariants = cva(
+    "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+    {
+        variants: {
+            variant: {
+                default: "bg-card text-card-foreground",
+                destructive:
+                    "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+        },
+    },
+);
+
+function Alert({
+    className,
+    variant,
+    ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+    return (
+        <div
+            data-slot="alert"
+            role="alert"
+            className={cn(alertVariants({ variant }), className)}
+            {...props}
+        />
+    );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="alert-title"
+            className={cn(
+                "[&_a]:hover:text-foreground font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function AlertDescription({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="alert-description"
+            className={cn(
+                "text-muted-foreground [&_a]:hover:text-foreground text-sm text-balance md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="alert-action"
+            className={cn("absolute top-2 right-2", className)}
+            {...props}
+        />
+    );
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction };

--- a/src/components/ui/alertDialog.tsx
+++ b/src/components/ui/alertDialog.tsx
@@ -21,7 +21,7 @@ function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdr
         <AlertDialogPrimitive.Backdrop
             data-slot="alert-dialog-overlay"
             className={cn(
-                "data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs",
+                "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs",
                 className,
             )}
             {...props}
@@ -43,7 +43,7 @@ function AlertDialogContent({
                 data-slot="alert-dialog-content"
                 data-size={size}
                 className={cn(
-                    "group/alert-dialog-content bg-popover text-popover-foreground ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl p-4 ring-1 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm",
+                    "group/alert-dialog-content bg-popover text-popover-foreground ring-foreground/10 fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl p-4 ring-1 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm",
                     className,
                 )}
                 {...props}
@@ -123,8 +123,21 @@ function AlertDialogDescription({
     );
 }
 
-function AlertDialogAction({ className, ...props }: React.ComponentProps<typeof Button>) {
-    return <Button data-slot="alert-dialog-action" className={cn(className)} {...props} />;
+function AlertDialogAction({
+    className,
+    variant = "default",
+    size = "default",
+    ...props
+}: AlertDialogPrimitive.Close.Props &
+    Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+    return (
+        <AlertDialogPrimitive.Close
+            data-slot="alert-dialog-action"
+            className={cn(className)}
+            render={<Button variant={variant} size={size} />}
+            {...props}
+        />
+    );
 }
 
 function AlertDialogCancel({

--- a/src/db.ts
+++ b/src/db.ts
@@ -77,8 +77,10 @@ export async function getAllSiteUsage() {
 }
 
 export async function setAllSiteUsage(data: SiteUsage[]) {
-    await database.siteUsage.clear();
-    await database.siteUsage.bulkAdd(data);
+    await database.transaction("readwrite", database.siteUsage, async () => {
+        await database.siteUsage.clear();
+        await database.siteUsage.bulkAdd(data);
+    });
 }
 
 export async function getSiteUsageByDate(day: DateKey): Promise<SiteUsage | undefined>;

--- a/src/db.ts
+++ b/src/db.ts
@@ -76,6 +76,11 @@ export async function getAllSiteUsage() {
     return siteUsage.length === 0 ? undefined : siteUsage;
 }
 
+export async function setAllSiteUsage(data: SiteUsage[]) {
+    await database.siteUsage.clear();
+    await database.siteUsage.bulkAdd(data);
+}
+
 export async function getSiteUsageByDate(day: DateKey): Promise<SiteUsage | undefined>;
 export async function getSiteUsageByDate(day: DateKey[]): Promise<SiteUsage[] | undefined>;
 export async function getSiteUsageByDate(day: DateKey | DateKey[]) {

--- a/src/lib/dashboardUtils.ts
+++ b/src/lib/dashboardUtils.ts
@@ -92,3 +92,12 @@ export function getOriginWithoutSuffix(origin: string) {
     const websiteName = getDomainWithoutSuffix(origin) ?? origin;
     return capitalize(websiteName);
 }
+
+export function isValidDateKey(value: string): boolean {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        return false;
+    }
+
+    const date = new Date(`${value}T00:00:00`);
+    return !Number.isNaN(date.getTime());
+}

--- a/src/lib/dashboardUtils.ts
+++ b/src/lib/dashboardUtils.ts
@@ -98,6 +98,13 @@ export function isValidDateKey(value: string): boolean {
         return false;
     }
 
+    const [year, month, day] = value.split("-").map(Number);
+
     const date = new Date(`${value}T00:00:00`);
-    return !Number.isNaN(date.getTime());
+    if (Number.isNaN(date.getTime())) {
+        return false;
+    }
+
+    // If value is 2022-02-34, new Date() will normalize them instead of rejecting them. So we need to check manually
+    return date.getFullYear() === year && date.getMonth() + 1 === month && date.getDate() === day;
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,5 @@
+export class InvalidImportJson extends Error {
+    constructor(message: string) {
+        super(message);
+    }
+}

--- a/src/lib/zodSchema.ts
+++ b/src/lib/zodSchema.ts
@@ -4,19 +4,7 @@ import type { DateKey } from "@app-types/types";
 
 const SiteUsage = z.object({
     day: z.custom<DateKey>((arg) => typeof arg === "string" && isValidDateKey(arg)),
-
-    // Skip records where
-    usage: z.record(z.string(), z.number().nonnegative()).transform((arg) => {
-        const out: Record<string, number> = {};
-        for (const [key, value] of Object.entries(arg)) {
-            const keyResult = z.url().safeParse(key);
-            const valueResult = z.number().nonnegative().safeParse(value);
-            if (keyResult.success && valueResult.success) {
-                out[keyResult.data] = valueResult.data;
-            }
-        }
-        return out;
-    }),
+    usage: z.record(z.string(), z.number().nonnegative()),
 });
 
 export const ImportSchema = z.array(SiteUsage);

--- a/src/lib/zodSchema.ts
+++ b/src/lib/zodSchema.ts
@@ -4,7 +4,19 @@ import type { DateKey } from "@app-types/types";
 
 const SiteUsage = z.object({
     day: z.custom<DateKey>((arg) => typeof arg === "string" && isValidDateKey(arg)),
-    usage: z.record(z.url(), z.number().nonnegative()),
+
+    // Skip records where
+    usage: z.record(z.string(), z.number().nonnegative()).transform((arg) => {
+        const out: Record<string, number> = {};
+        for (const [key, value] of Object.entries(arg)) {
+            const keyResult = z.url().safeParse(key);
+            const valueResult = z.number().nonnegative().safeParse(value);
+            if (keyResult.success && valueResult.success) {
+                out[keyResult.data] = valueResult.data;
+            }
+        }
+        return out;
+    }),
 });
 
 export const ImportSchema = z.array(SiteUsage);

--- a/src/lib/zodSchema.ts
+++ b/src/lib/zodSchema.ts
@@ -1,0 +1,10 @@
+import * as z from "zod";
+import { isValidDateKey } from "./dashboardUtils";
+import type { DateKey } from "@app-types/types";
+
+const SiteUsage = z.object({
+    day: z.custom<DateKey>((arg) => typeof arg === "string" && isValidDateKey(arg)),
+    usage: z.record(z.url(), z.number().nonnegative()),
+});
+
+export const ImportSchema = z.array(SiteUsage);

--- a/src/pages/dashboard/overview/chartSection.tsx
+++ b/src/pages/dashboard/overview/chartSection.tsx
@@ -4,6 +4,7 @@ import { NavLink } from "react-router";
 import { Chart } from "../chart/chart";
 import ChartSites from "../chart/chartSites";
 import { CalendarDays, Database, Globe, type LucideIcon } from "lucide-react";
+import NoUsageData from "../shared/noUsageData";
 
 function ChartSwitchBtn({
     to,
@@ -34,9 +35,13 @@ export function UsageChartSection({
     usage,
     chart,
 }: {
-    usage: SiteUsage[];
+    usage: SiteUsage[] | null;
     chart: "daily" | "sites";
 }) {
+    if (!usage) {
+        return <NoUsageData />;
+    }
+
     const dayCount = usage.length;
     return (
         <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-white/8 bg-[#1d1d1d] px-4 pt-3.5">

--- a/src/pages/dashboard/overview/clearUsageButton.tsx
+++ b/src/pages/dashboard/overview/clearUsageButton.tsx
@@ -25,9 +25,7 @@ export default function ClearUsageButton() {
             buttonText={"Clear All Usage Data"}
             className="w-full"
             disabled={isClearingPending}
-            onConfirm={() => {
-                clearUsage();
-            }}
+            onConfirm={clearUsage}
         />
     );
 }

--- a/src/pages/dashboard/overview/clearUsageButton.tsx
+++ b/src/pages/dashboard/overview/clearUsageButton.tsx
@@ -23,7 +23,7 @@ export default function ClearUsageButton() {
         <AlertDialogBasic
             descriptionText="This action cannot be undone. This will permanently delete your usage"
             buttonText={"Clear All Usage Data"}
-            className="mt-2.5"
+            className="w-full"
             disabled={isClearingPending}
             onConfirm={() => {
                 clearUsage();

--- a/src/pages/dashboard/overview/dashboard.tsx
+++ b/src/pages/dashboard/overview/dashboard.tsx
@@ -1,10 +1,10 @@
 import { DashboardSkeleton } from "./dashboardSkeleton";
 import DashboardBanner from "./dashboardBanner";
-import ClearUsageButton from "./clearUsageButton";
 import NoUsageData from "../shared/noUsageData";
 import { useSiteUsage } from "@hooks/useSiteUsage";
 import { StatsRow } from "./statsRow";
 import { UsageChartSection } from "./chartSection";
+import { FooterBtns } from "./footerBtns";
 
 export default function Dashboard({ chart }: { chart: "daily" | "sites" }) {
     const { data: usage, isPending, isError, error } = useSiteUsage();
@@ -19,7 +19,7 @@ export default function Dashboard({ chart }: { chart: "daily" | "sites" }) {
             <div className="flex flex-1 flex-col bg-neutral-950/70 px-6 pt-1 pb-3.5">
                 <StatsRow usage={usage} />
                 <UsageChartSection chart={chart} usage={usage} />
-                <ClearUsageButton />
+                <FooterBtns />
             </div>
         </>
     );

--- a/src/pages/dashboard/overview/dashboard.tsx
+++ b/src/pages/dashboard/overview/dashboard.tsx
@@ -19,9 +19,15 @@ export default function Dashboard({ chart }: { chart: "daily" | "sites" }) {
 
     return (
         <>
+            {btnError && (
+                <AlertDestructive
+                    title={btnError.message}
+                    description="Please try again"
+                    onClose={() => setError(undefined)}
+                />
+            )}
             <DashboardBanner />
             <div className="flex flex-1 flex-col bg-neutral-950/70 px-6 pt-1 pb-3.5">
-                {btnError && <AlertDestructive title={btnError.message} />}
                 <StatsRow usage={usage} />
                 <UsageChartSection chart={chart} usage={usage} />
                 <FooterBtns setError={setError} />

--- a/src/pages/dashboard/overview/dashboard.tsx
+++ b/src/pages/dashboard/overview/dashboard.tsx
@@ -1,6 +1,5 @@
 import { DashboardSkeleton } from "./dashboardSkeleton";
 import DashboardBanner from "./dashboardBanner";
-import NoUsageData from "../shared/noUsageData";
 import { useSiteUsage } from "@hooks/useSiteUsage";
 import { StatsRow } from "./statsRow";
 import { UsageChartSection } from "./chartSection";
@@ -15,20 +14,15 @@ export default function Dashboard({ chart }: { chart: "daily" | "sites" }) {
 
     if (isPending) return <DashboardSkeleton />;
     if (isError) throw error;
-    if (!usage) return <NoUsageData />;
 
     return (
         <>
             {btnError && (
-                <AlertDestructive
-                    title={btnError.message}
-                    description="Please try again"
-                    onClose={() => setError(undefined)}
-                />
+                <AlertDestructive title={btnError.message} onClose={() => setError(undefined)} />
             )}
             <DashboardBanner />
             <div className="flex flex-1 flex-col bg-neutral-950/70 px-6 pt-1 pb-3.5">
-                <StatsRow usage={usage} />
+                <StatsRow usage={usage ?? []} />
                 <UsageChartSection chart={chart} usage={usage} />
                 <FooterBtns setError={setError} />
             </div>

--- a/src/pages/dashboard/overview/dashboard.tsx
+++ b/src/pages/dashboard/overview/dashboard.tsx
@@ -5,9 +5,13 @@ import { useSiteUsage } from "@hooks/useSiteUsage";
 import { StatsRow } from "./statsRow";
 import { UsageChartSection } from "./chartSection";
 import { FooterBtns } from "./footerBtns";
+import type { InvalidImportJson } from "@lib/errors";
+import { useState } from "react";
+import { AlertDestructive } from "@components/alertDestructive";
 
 export default function Dashboard({ chart }: { chart: "daily" | "sites" }) {
     const { data: usage, isPending, isError, error } = useSiteUsage();
+    const [btnError, setError] = useState<InvalidImportJson>();
 
     if (isPending) return <DashboardSkeleton />;
     if (isError) throw error;
@@ -17,9 +21,10 @@ export default function Dashboard({ chart }: { chart: "daily" | "sites" }) {
         <>
             <DashboardBanner />
             <div className="flex flex-1 flex-col bg-neutral-950/70 px-6 pt-1 pb-3.5">
+                {btnError && <AlertDestructive title={btnError.message} />}
                 <StatsRow usage={usage} />
                 <UsageChartSection chart={chart} usage={usage} />
-                <FooterBtns />
+                <FooterBtns setError={setError} />
             </div>
         </>
     );

--- a/src/pages/dashboard/overview/exportToJsonBtn.tsx
+++ b/src/pages/dashboard/overview/exportToJsonBtn.tsx
@@ -1,14 +1,16 @@
 import { Button } from "@components/ui/button";
 import { getAllSiteUsage } from "@/db";
-import { useState } from "react";
-import { AlertDestructive } from "@components/alertDestructive";
+import { InvalidImportJson } from "@lib/errors";
 
-export function ExportToJsonBtn() {
-    const [isAlert, setAlert] = useState(false);
-
+export function ExportToJsonBtn({
+    setError,
+}: {
+    setError: React.Dispatch<React.SetStateAction<InvalidImportJson | undefined>>;
+}) {
     async function getData() {
         const siteUsage = await getAllSiteUsage();
-        if (!siteUsage || siteUsage.length === 0) setAlert(true);
+        if (!siteUsage || siteUsage.length === 0)
+            setError(new InvalidImportJson("There is no usage to export"));
 
         const json = JSON.stringify(siteUsage);
         const blob = new Blob([json]);
@@ -24,10 +26,9 @@ export function ExportToJsonBtn() {
             variant="outline"
             className="w-full"
             onClick={() => {
-                void getData();
+                getData().catch((err) => setError(err as Error));
             }}
         >
-            {isAlert && <AlertDestructive title="Failed to Export your data" />}
             Export To JSON
         </Button>
     );

--- a/src/pages/dashboard/overview/exportToJsonBtn.tsx
+++ b/src/pages/dashboard/overview/exportToJsonBtn.tsx
@@ -1,6 +1,21 @@
 import { Button } from "@components/ui/button";
-import { getAllSiteUsage } from "@/db";
+import { getAllSiteUsage, type SiteUsage } from "@/db";
 import { InvalidImportJson } from "@lib/errors";
+import * as z from "zod";
+
+function filterUsage(siteUsage: SiteUsage[]) {
+    return siteUsage.map(({ day, usage }) => {
+        const values = Object.entries(usage).filter(([url, bytes]) => {
+            const urlResult = z.url().safeParse(url);
+            const bytesResult = z.number().nonnegative().safeParse(bytes);
+            return urlResult.success && bytesResult.success;
+        });
+
+        const usageRecords = Object.fromEntries(values) as Record<string, number>;
+
+        return { day, usage: usageRecords };
+    });
+}
 
 export function ExportToJsonBtn({
     setError,
@@ -10,7 +25,11 @@ export function ExportToJsonBtn({
     async function getData() {
         const siteUsage = await getAllSiteUsage();
         if (!siteUsage || siteUsage.length === 0)
-            setError(new InvalidImportJson("There is no usage to export"));
+            return setError(new InvalidImportJson("There is no usage to export"));
+
+        const filteredUsage = filterUsage(siteUsage);
+        if (filteredUsage.length === 0)
+            return setError(new InvalidImportJson("There is no usage to export"));
 
         const json = JSON.stringify(siteUsage);
         const blob = new Blob([json]);
@@ -19,6 +38,8 @@ export function ExportToJsonBtn({
         a.href = blobUrl;
         a.download = `tubesize-${new Date().toISOString().split("T")[0]}.json`;
         a.click();
+
+        return blobUrl;
     }
 
     return (
@@ -26,7 +47,9 @@ export function ExportToJsonBtn({
             variant="outline"
             className="w-full"
             onClick={() => {
-                getData().catch((err) => setError(err as Error));
+                getData()
+                    .then((u) => u && URL.revokeObjectURL(u))
+                    .catch((err) => setError(err as Error));
             }}
         >
             Export To JSON

--- a/src/pages/dashboard/overview/exportToJsonBtn.tsx
+++ b/src/pages/dashboard/overview/exportToJsonBtn.tsx
@@ -4,16 +4,17 @@ import { InvalidImportJson } from "@lib/errors";
 import * as z from "zod";
 
 function filterUsage(siteUsage: SiteUsage[]) {
-    return siteUsage.map(({ day, usage }) => {
+    return siteUsage.flatMap(({ day, usage }) => {
         const values = Object.entries(usage).filter(([url, bytes]) => {
             const urlResult = z.url().safeParse(url);
             const bytesResult = z.number().nonnegative().safeParse(bytes);
             return urlResult.success && bytesResult.success;
         });
 
+        if (values.length === 0) return [];
         const usageRecords = Object.fromEntries(values) as Record<string, number>;
 
-        return { day, usage: usageRecords };
+        return [{ day, usage: usageRecords }];
     });
 }
 
@@ -31,7 +32,7 @@ export function ExportToJsonBtn({
         if (filteredUsage.length === 0)
             return setError(new InvalidImportJson("There is no usage to export"));
 
-        const json = JSON.stringify(siteUsage);
+        const json = JSON.stringify(filteredUsage);
         const blob = new Blob([json]);
         const blobUrl = URL.createObjectURL(blob);
         const a = document.createElement("a");

--- a/src/pages/dashboard/overview/exportToJsonBtn.tsx
+++ b/src/pages/dashboard/overview/exportToJsonBtn.tsx
@@ -1,0 +1,34 @@
+import { Button } from "@components/ui/button";
+import { getAllSiteUsage } from "@/db";
+import { useState } from "react";
+import { AlertDestructive } from "@components/alertDestructive";
+
+export function ExportToJsonBtn() {
+    const [isAlert, setAlert] = useState(false);
+
+    async function getData() {
+        const siteUsage = await getAllSiteUsage();
+        if (!siteUsage || siteUsage.length === 0) setAlert(true);
+
+        const json = JSON.stringify(siteUsage);
+        const blob = new Blob([json]);
+        const blobUrl = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = blobUrl;
+        a.download = `tubesize-${new Date().toISOString().split("T")[0]}.json`;
+        a.click();
+    }
+
+    return (
+        <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => {
+                void getData();
+            }}
+        >
+            {isAlert && <AlertDestructive title="Failed to Export your data" />}
+            Export To JSON
+        </Button>
+    );
+}

--- a/src/pages/dashboard/overview/footerBtns.tsx
+++ b/src/pages/dashboard/overview/footerBtns.tsx
@@ -1,0 +1,19 @@
+import ClearUsageButton from "./clearUsageButton";
+import { ExportToJsonBtn } from "./exportToJsonBtn";
+import { ImportJson } from "./importJson";
+
+export function FooterBtns() {
+    return (
+        <div className="mt-2.5 flex items-center gap-1">
+            <div className="flex-3">
+                <ClearUsageButton />
+            </div>
+            <div className="flex-1">
+                <ExportToJsonBtn />
+            </div>
+            <div className="flex-1">
+                <ImportJson />
+            </div>
+        </div>
+    );
+}

--- a/src/pages/dashboard/overview/footerBtns.tsx
+++ b/src/pages/dashboard/overview/footerBtns.tsx
@@ -1,18 +1,23 @@
+import type { InvalidImportJson } from "@lib/errors";
 import ClearUsageButton from "./clearUsageButton";
 import { ExportToJsonBtn } from "./exportToJsonBtn";
 import { ImportJson } from "./importJson";
 
-export function FooterBtns() {
+export function FooterBtns({
+    setError,
+}: {
+    setError: React.Dispatch<React.SetStateAction<InvalidImportJson | undefined>>;
+}) {
     return (
         <div className="mt-2.5 flex items-center gap-1">
             <div className="flex-3">
                 <ClearUsageButton />
             </div>
             <div className="flex-1">
-                <ExportToJsonBtn />
+                <ExportToJsonBtn setError={setError} />
             </div>
             <div className="flex-1">
-                <ImportJson />
+                <ImportJson setError={setError} />
             </div>
         </div>
     );

--- a/src/pages/dashboard/overview/importJson.tsx
+++ b/src/pages/dashboard/overview/importJson.tsx
@@ -19,7 +19,7 @@ async function importJson() {
                 .then((textFile) => {
                     const siteUsage = JSON.parse(textFile) as SiteUsage[];
                     const result = ImportSchema.safeParse(siteUsage);
-                    if (!result.success) throw new Error("Invalid JSON");
+                    if (!result.success) throw new Error(result.error.message);
                     return result.data;
                 })
                 .then((data) => {
@@ -44,6 +44,7 @@ export function ImportJson({
             variant="outline"
             className="w-full"
             onClick={() => {
+                setError(undefined);
                 importJson()
                     .then(() => void queryClient.invalidateQueries({ queryKey: ["siteUsage"] }))
                     .catch((err) => {

--- a/src/pages/dashboard/overview/importJson.tsx
+++ b/src/pages/dashboard/overview/importJson.tsx
@@ -3,7 +3,6 @@ import { Button } from "@components/ui/button";
 import type { InvalidImportJson } from "@lib/errors";
 import { ImportSchema } from "@lib/zodSchema";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
 
 async function importJson() {
     return new Promise((resolve, reject) => {
@@ -33,11 +32,13 @@ async function importJson() {
     });
 }
 
-export function ImportJson() {
+export function ImportJson({
+    setError,
+}: {
+    setError: React.Dispatch<React.SetStateAction<InvalidImportJson | undefined>>;
+}) {
     const queryClient = useQueryClient();
-    const [error, setError] = useState<Error>();
 
-    if (error) throw error;
     return (
         <Button
             variant="outline"

--- a/src/pages/dashboard/overview/importJson.tsx
+++ b/src/pages/dashboard/overview/importJson.tsx
@@ -1,6 +1,5 @@
 import { setAllSiteUsage, type SiteUsage } from "@/db";
 import { AlertDialogBasic } from "@components/alertDialogBasic";
-import { Button } from "@components/ui/button";
 import type { InvalidImportJson } from "@lib/errors";
 import { ImportSchema } from "@lib/zodSchema";
 import { useQueryClient } from "@tanstack/react-query";

--- a/src/pages/dashboard/overview/importJson.tsx
+++ b/src/pages/dashboard/overview/importJson.tsx
@@ -1,4 +1,5 @@
 import { setAllSiteUsage, type SiteUsage } from "@/db";
+import { AlertDialogBasic } from "@components/alertDialogBasic";
 import { Button } from "@components/ui/button";
 import type { InvalidImportJson } from "@lib/errors";
 import { ImportSchema } from "@lib/zodSchema";
@@ -40,20 +41,21 @@ export function ImportJson({
     const queryClient = useQueryClient();
 
     return (
-        <Button
-            variant="outline"
-            className="w-full"
-            onClick={() => {
-                setError(undefined);
-                importJson()
-                    .then(() => void queryClient.invalidateQueries({ queryKey: ["siteUsage"] }))
-                    .catch((err) => {
-                        console.log(err);
-                        setError(err as Error);
-                    });
-            }}
-        >
-            Import JSON
-        </Button>
+        <>
+            <AlertDialogBasic
+                descriptionText="Importing usage will COMPLETELY REPLACE your usage. Are you sure you want to continue?"
+                buttonText="Import JSON"
+                className="w-full"
+                onConfirm={() => {
+                    setError(undefined);
+                    importJson()
+                        .then(() => void queryClient.invalidateQueries({ queryKey: ["siteUsage"] }))
+                        .catch((err) => {
+                            console.log(err);
+                            setError(err as Error);
+                        });
+                }}
+            />
+        </>
     );
 }

--- a/src/pages/dashboard/overview/importJson.tsx
+++ b/src/pages/dashboard/overview/importJson.tsx
@@ -1,0 +1,57 @@
+import { setAllSiteUsage, type SiteUsage } from "@/db";
+import { Button } from "@components/ui/button";
+import type { InvalidImportJson } from "@lib/errors";
+import { ImportSchema } from "@lib/zodSchema";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+async function importJson() {
+    return new Promise((resolve, reject) => {
+        const input = document.createElement("input");
+        input.type = "file";
+        input.accept = ".json";
+
+        input.click();
+
+        input.addEventListener("change", () => {
+            const file = input.files?.item(0);
+            if (!file) return;
+            file.text()
+                .then((textFile) => {
+                    const siteUsage = JSON.parse(textFile) as SiteUsage[];
+                    const result = ImportSchema.safeParse(siteUsage);
+                    if (!result.success) throw new Error("Invalid JSON");
+                    return result.data;
+                })
+                .then((data) => {
+                    return resolve(setAllSiteUsage(data));
+                })
+                .catch((err) => {
+                    return reject(err as InvalidImportJson);
+                });
+        });
+    });
+}
+
+export function ImportJson() {
+    const queryClient = useQueryClient();
+    const [error, setError] = useState<Error>();
+
+    if (error) throw error;
+    return (
+        <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => {
+                importJson()
+                    .then(() => void queryClient.invalidateQueries({ queryKey: ["siteUsage"] }))
+                    .catch((err) => {
+                        console.log(err);
+                        setError(err as Error);
+                    });
+            }}
+        >
+            Import JSON
+        </Button>
+    );
+}

--- a/src/pages/dashboard/platform/platformUsage.tsx
+++ b/src/pages/dashboard/platform/platformUsage.tsx
@@ -19,7 +19,7 @@ export default function PlatformUsage() {
 
     const historyQuery = useWatchHistory(scope);
 
-    const watchHistory = historyQuery.data?.history;
+    const watchHistory = historyQuery.data?.history ?? [];
     const metadataQuery = useVideoMetadata();
 
     if (!platformId || !isPlatformId(platformId)) {
@@ -31,7 +31,6 @@ export default function PlatformUsage() {
     if (metadataQuery.isPending) return <VideosTableSkeleton />;
     if (metadataQuery.isError) throw metadataQuery.error;
 
-    if (!watchHistory) return <NoUsageData />;
     const metadata = metadataQuery.data ?? [];
 
     // Merge Watch History and Video Metadata into one Array shape.
@@ -83,7 +82,11 @@ export default function PlatformUsage() {
                 </div>
 
                 <div className="flex flex-1 flex-col rounded-2xl border border-neutral-800 bg-neutral-900">
-                    <VideosTable rows={rows} platform={platform} />
+                    {rows.length === 0 ? (
+                        <NoUsageData />
+                    ) : (
+                        <VideosTable rows={rows} platform={platform} />
+                    )}
                 </div>
             </div>
         </>

--- a/src/pages/dashboard/platform/videosTable.tsx
+++ b/src/pages/dashboard/platform/videosTable.tsx
@@ -1,7 +1,6 @@
 import type { PlatformId } from "@app-types/types";
 import VideoTableRow from "./videoTableRow";
 import type { VideoRowDetails } from "./videoTableRow";
-
 export type { VideoRowDetails } from "./videoTableRow";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 

--- a/src/pages/dashboard/scope/scopePage.tsx
+++ b/src/pages/dashboard/scope/scopePage.tsx
@@ -1,4 +1,4 @@
-import { formatDate } from "@lib/dashboardUtils";
+import { formatDate, isValidDateKey } from "@lib/dashboardUtils";
 import DashboardHeader from "@pages/dashboard/shared/dashboardHeader";
 import VideosTableSkeleton from "@pages/dashboard/platform/videosTableSkeleton";
 import NoUsageData from "@pages/dashboard/shared/noUsageData";
@@ -40,21 +40,12 @@ function getScope(date: DateKey | undefined): UsageScope | undefined {
             range: date as UsageRange,
         };
     }
-    if (isValidDate(date)) {
+    if (isValidDateKey(date)) {
         return {
             type: "date",
             date,
         };
     }
-}
-
-function isValidDate(value: string): boolean {
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-        return false;
-    }
-
-    const date = new Date(`${value}T00:00:00`);
-    return !Number.isNaN(date.getTime());
 }
 
 export function ScopePage() {

--- a/src/pages/dashboard/scope/scopePage.tsx
+++ b/src/pages/dashboard/scope/scopePage.tsx
@@ -57,7 +57,14 @@ export function ScopePage() {
     if (!scope) return <DashboardNotFound />;
     if (isPending) return <VideosTableSkeleton />;
     if (isError) throw error;
-    if (!usage) return <NoUsageData />;
+
+    if (!usage || usage.length === 0)
+        return (
+            <>
+                <DashboardHeader title={getTitle(scope)} totalDataUsage={0} />
+                <NoUsageData />
+            </>
+        );
 
     return (
         <>

--- a/src/pages/dashboard/shared/dashboardError.tsx
+++ b/src/pages/dashboard/shared/dashboardError.tsx
@@ -4,9 +4,9 @@ export default function DashboardErrorPage({ error }: { error: unknown }) {
     const routeError = error;
     const message = routeError instanceof Error ? routeError.message : String(routeError);
     return (
-        <>
+        <div className="flex h-screen flex-col">
             <DashboardBanner />
-            <div className="flex flex-1 items-center justify-center bg-neutral-950 p-8">
+            <div className="flex flex-1 items-center justify-center overflow-x-clip bg-neutral-950">
                 <div className="flex max-w-md flex-col items-center gap-3 rounded-lg border border-dashed border-red-900 bg-[#221718] px-10 py-8 text-center font-mono">
                     <span className="text-2xl text-red-400">⚠</span>
                     <span className="text-base text-stone-200">Something went wrong</span>
@@ -18,6 +18,6 @@ export default function DashboardErrorPage({ error }: { error: unknown }) {
                     </div>
                 </div>
             </div>
-        </>
+        </div>
     );
 }

--- a/src/pages/dashboard/shared/noUsageData.tsx
+++ b/src/pages/dashboard/shared/noUsageData.tsx
@@ -1,7 +1,7 @@
 export default function NoUsageData() {
     return (
         <div className="flex flex-1 items-center justify-center rounded-lg border border-white/8 bg-[#1d1d1d] p-8">
-            <div className="flex min-w-lg flex-col items-center gap-3 rounded-lg border border-dashed border-neutral-700 bg-neutral-900 px-10 py-8 font-mono text-teal-400">
+            <div className="flex w-full max-w-lg flex-col items-center gap-3 rounded-lg border border-dashed border-neutral-700 bg-neutral-900 px-10 py-8 font-mono text-teal-400">
                 <img
                     className="h-10 w-10 opacity-60"
                     src="/icons/icon-32.png"

--- a/src/pages/dashboard/shared/noUsageData.tsx
+++ b/src/pages/dashboard/shared/noUsageData.tsx
@@ -1,19 +1,17 @@
 export default function NoUsageData() {
     return (
-        <>
-            <div className="flex flex-1 items-center justify-center bg-neutral-950 p-8">
-                <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-neutral-700 bg-neutral-900 px-10 py-8 font-mono text-teal-400">
-                    <img
-                        className="h-10 w-10 opacity-60"
-                        src="/icons/icon-32.png"
-                        alt="Dashboard Icon"
-                    />
-                    <span className="text-base">No usage data available.</span>
-                    <span className="text-xs text-neutral-500">
-                        Watch a YouTube video to start tracking your usage statistics.
-                    </span>
-                </div>
+        <div className="flex flex-1 items-center justify-center rounded-lg border border-white/8 bg-[#1d1d1d] p-8">
+            <div className="flex min-w-lg flex-col items-center gap-3 rounded-lg border border-dashed border-neutral-700 bg-neutral-900 px-10 py-8 font-mono text-teal-400">
+                <img
+                    className="h-10 w-10 opacity-60"
+                    src="/icons/icon-32.png"
+                    alt="Dashboard Icon"
+                />
+                <span className="text-base">No usage data available.</span>
+                <span className="text-xs text-neutral-500">
+                    Start visiting websites to see Usage
+                </span>
             </div>
-        </>
+        </div>
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added dashboard buttons to clear, export, and import site usage data.
- Exported site usage data as a date-stamped JSON file.
- Validated imported JSON with `ImportSchema` before replacing stored data.
- Added import error handling and destructive alert components.
- Added shared date-key validation and reused it in `ScopePage`.
- Added `setAllSiteUsage` for bulk database updates.
- Updated dashboard footer and error-page layout styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->